### PR TITLE
Restate audit finding A3 against the code that landed the day after it

### DIFF
--- a/docs/development/audit-2026-08-05.md
+++ b/docs/development/audit-2026-08-05.md
@@ -25,6 +25,7 @@ and a finding that recurs is more informative than one that vanishes.
 | 2026-08-06 | B4, B7 | The optimizer contract lives in `opensdl-core`, so a third-party optimizer depends on a protocol and a few frozen models rather than on storage, policy, workflows and SQLAlchemy; the sole boundary exception is gone, and `CampaignDefinition` can declare what the runner accepts, checked in both directions. A campaign resumes from its own record: completed work is not repeated, iteration numbering continues, a second start under one identifier is refused, and a resume over a run whose physical outcome is unknown is refused rather than laundered. |
 | 2026-08-10 | A4 (blast radius), third instance of the A1/A2 class | Restart reconciliation asked "may this be repeated when nothing reported an outcome?" for itself instead of reading `retry_safety`, contradicting the timeout path in the same file. One helper, `may_repeat_without_outcome`, now serves every path that asks it without an outcome in hand. An interrupted task whose capability declares `repeatable` is recorded `FAILED` and resumes; every other declaration, and an unknown capability, still records `INTERVENTION_REQUIRED`. So a restart no longer permanently ends a campaign built from capabilities that had declared repeating harmless. A4's blast radius is bounded accordingly, and the `--help`, docstring, CLI reference and onboarding text that described the old unconditional behaviour are corrected. The other half is unchanged: no operation acknowledges an intervention, so `INTERVENTION_REQUIRED` remains terminal for everything else — still tracked in Backlog §4. |
 | 2026-08-10 | A7 | The consecutive-failure limit counts batches that completed nothing rather than observations that did not succeed, so a laboratory asked to run more at once than it owns no longer stops on its first batch reporting the failure as systematic. A batch that completed nothing still counts every attempt in it, so a genuinely failing laboratory stops as promptly as before, and `batch_size=1` is unchanged in every case. A6 remains open, and so does the larger half of A7: a candidate that lost a race is still recorded as a failed evaluation it never received. |
+| 2026-08-10 | A3 (restated, one limit closed) | This finding was written the day before `OutcomeConstraint` landed and had read as more absolute than the code ever since. A deployment-declared feasibility criterion with the recorded third outcome does exist at campaign level; what is missing is narrower and is now stated as four specific limits. The sharpest of them — that a criterion which is not a measurement had no expression at all — is closed by `equals`. The remaining three are one output path per constraint, no access to task inputs or history, and no per-task postcondition, which is the form `SAFETY.md:34` requires. |
 | 2026-08-07 | Decision 4 (the C5 mutation case), B7 (remaining half) | `RunCreated` carries a canonical digest of the workflow document it captured and a resume must present the same document, so a non-terminal run can no longer be turned into a different execution under the original operator's name; `supersedes` mints a new run naming the one it replaces, recorded on both. Starting a run is one conditional write over the states the declared machine already permitted, so two callers can no longer both enter `run_workflow` on the same running run. `CampaignObservation`, `Suggestion` and `CampaignProblem` are typed models with generated schemas, and the hand-rolled serialisation whose keys matched nothing published is gone. |
 
 ## Decisions the owner has to make
@@ -290,6 +291,29 @@ validation, be physically re-measured (A2), and then fail the run.
 There is no path from "the instrument says this datum is untrustworthy" to "record it, quarantine
 it, escalate". This is the failure mode that costs a 200-run campaign silently; everything else
 announces itself.
+
+**Partly addressed at the campaign level on 2026-08-06, one day after this was written, and this
+finding did not say so.** `OutcomeConstraint` (`packages/core/src/opensdl_core/campaign.py:257`,
+added in `b654008`) is deployment-declared, is evaluated against a run's outputs, and carries exactly
+the third outcome asked for above: a violating observation is recorded, keeps its numbers, is
+excluded from the best and from reaching a target, and does not fail the run. So the sentence "the
+only mechanism that exists is JSON Schema validation" is no longer true.
+
+Four limits were identified. The first is now closed; three remain, and they are the residual work:
+
+- ~~**Numeric only.**~~ **Closed 2026-08-10.** `as_number` (`campaign.py`) rejects `bool` on the
+  correct ground that a `bool` is an `int` in Python and is not a measurement, and nothing had been
+  put beside it, so "the solver reported convergence: yes or no" was inexpressible. `equals` now
+  states an exact value, keeping `bool`, `int` and `str` apart because `True == 1` in Python. Floats
+  are excluded deliberately: exact equality on a measured quantity is almost never the criterion,
+  and `lower` with `upper` says the intended thing.
+- **One output per constraint.** `output` is a single dotted path, so a criterion relating two
+  quantities has to be precomputed by whatever parses the code's output, which moves the criterion
+  into the adapter and out of the document.
+- **Outputs only.** There is no access to the task's inputs or to prior runs, so "within 5% of what
+  was commanded" and any drift criterion remain unexpressible — the original point above, unchanged.
+- **Campaign level only.** A workflow task has no postcondition gate, which is the form
+  `SAFETY.md:34` actually requires.
 
 ### A4 — `opensdl doctor` silently reconciles active runs [verified] · M
 


### PR DESCRIPTION
A3 states that the only postcondition mechanism anywhere is adapter-declared JSON Schema validation. That was accurate on 2026-08-05. `OutcomeConstraint` landed on 2026-08-06 in `b654008`, and the finding has overstated the gap ever since.

What exists today, verified against source: `OutcomeConstraint` (`packages/core/src/opensdl_core/campaign.py:257`) is deployment-declared, is evaluated against a run's outputs, and carries exactly the third outcome A3 asks for — a violating observation keeps its numbers, is recorded, is excluded from the best and from reaching a target, and does not fail the run.

The residual gap is real but considerably narrower, and it is worth naming precisely because it is the next thing anyone builds here:

- **Numeric only.** `as_number` (`campaign.py:699`) rejects `bool` on the correct ground that a `bool` is an `int` in Python and is not a measurement — but `OutcomeConstraint` offers `lower`/`upper` and nothing was put beside it, so "the solver reported convergence: yes or no" is inexpressible.
- **One dotted output path per constraint**, so a criterion over two quantities migrates into the adapter and out of the document.
- **Outputs only** — no task inputs, no prior runs. A3's original point, unchanged.
- **Campaign level only** — no per-task postcondition, which is the form `SAFETY.md:34` requires.

No behaviour changes; this is the audit correcting itself. Found while comparing the framework against the incumbents in computational materials science, and verified here against the source rather than taken on report.

`make lint` and `make docs` pass.