### PR TITLE
Let a campaign state a criterion that is not a measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,15 @@ workspace has carried, not artifacts anyone can install. See
   while it was still being driven, so a second task could take it with no race and no contention
   involved — one other task starting was enough. The lease now covers every attempt the retry loop
   may make and the backoff between them, and the configured TTL is a floor rather than a ceiling;
+- an outcome constraint can declare `equals` as well as `lower` and `upper`, so a criterion that is
+  not a measurement — a solver reporting whether it converged, an instrument reporting whether it
+  trusts a datum — can be stated in a stored campaign instead of being recast as a number by
+  whatever parses the code's output. Exact values keep their type, because `True == 1` in Python and
+  a criterion declaring `true` is not met by a run reporting `1`. Floats are excluded: exact
+  equality on a measured quantity is almost never the intended criterion, and `lower` with `upper`
+  says the intended thing. Declaring a bound and an exact value together, and declaring an interval
+  whose lower bound exceeds its upper, are both now refused at load rather than silently failing
+  every run;
 - the long-form documents left the repository root for the published site. `ARCHITECTURE.md`,
   `DEVELOPMENT.md`, `ROADMAP.md`, `VALIDATION.md` and `IMPORT_PROVENANCE.md` are now
   `docs/architecture/overview.md`, `docs/development/index.md`, `docs/development/roadmap.md`,

--- a/docs/guides/closed-loop-campaign.md
+++ b/docs/guides/closed-loop-campaign.md
@@ -12,6 +12,19 @@ candidate outside it is refused before a run is created, a policy decision is ta
 leased. Every decision is recorded before the run it causes, naming the runs it rested on, the
 acquisition value and function, and the model that produced it. A campaign records why it stopped.
 
+A constraint on an outcome takes one of two forms, and a campaign declares whichever the criterion
+actually is. `lower` and `upper` bound a measurement. `equals` states an exact value for a criterion
+that is not a measurement at all — a solver reporting whether it converged, or an instrument
+reporting whether it trusts the datum it just produced. A bound and an exact value cannot both be
+declared on the same constraint, an inverted interval is refused at load rather than failing every
+run in silence, and an exact value keeps its type: a criterion declaring `true` is not met by a run
+reporting `1`.
+
+Violating an outcome constraint is not a failure. The run happened, the numbers are real, and they
+are recorded and handed to the optimizer as evidence about a candidate that does not satisfy the
+criterion. What the observation loses is its claim on the result: it is excluded from the best and
+cannot reach a target.
+
 An optimizer that proposes several candidates at once declares a batch size; a laboratory that can
 execute several at once declares its parallelism, which defaults to one, because how many candidates
 a method proposes and how many instruments a laboratory has are different questions.

--- a/packages/core/src/opensdl_core/campaign.py
+++ b/packages/core/src/opensdl_core/campaign.py
@@ -267,14 +267,28 @@ class OutcomeConstraint(OpenSDLModel):
     output: str
     lower: float | None = None
     upper: float | None = None
+    #: The exact value the output must carry, for a criterion that is not a measurement. A solver
+    #: reporting whether it converged, and an instrument reporting whether it trusts a datum, are
+    #: the cases `lower` and `upper` cannot express at all. Floats are deliberately excluded:
+    #: exact equality on a measured quantity is almost never what a criterion means, and `lower`
+    #: with `upper` says the intended thing.
+    equals: bool | int | str | None = None
     description: str = ""
 
     @model_validator(mode="after")
     def _is_bounded(self) -> OutcomeConstraint:
-        if self.lower is None and self.upper is None:
+        bounded = self.lower is not None or self.upper is not None
+        if bounded and self.equals is not None:
             raise ValueError(
-                f"outcome constraint {self.name} bounds nothing: declare lower, upper, or both"
+                f"outcome constraint {self.name} declares both a bound and an exact value: "
+                "a criterion is one or the other"
             )
+        if not bounded and self.equals is None:
+            raise ValueError(
+                f"outcome constraint {self.name} bounds nothing: declare lower, upper, or equals"
+            )
+        if self.lower is not None and self.upper is not None and self.lower > self.upper:
+            raise ValueError(f"outcome constraint {self.name} declares an empty interval")
         return self
 
     def violation(self, outputs: Mapping[str, Any]) -> str | None:
@@ -285,6 +299,10 @@ class OutcomeConstraint(OpenSDLModel):
                 f"{self.name}: the run reported no {self.output}, "
                 "so feasibility cannot be established"
             )
+        if self.equals is not None:
+            if matches_exactly(raw, self.equals):
+                return None
+            return f"{self.name}: {self.output}={raw!r} is not {self.equals!r}"
         value = as_number(raw)
         if value is None:
             return f"{self.name}: {self.output}={raw!r} is not a number"
@@ -702,6 +720,22 @@ def as_number(value: Any) -> float | None:
     if isinstance(value, bool) or not isinstance(value, int | float):
         return None
     return float(value)
+
+
+def matches_exactly(value: Any, expected: bool | int | str) -> bool:
+    """Exact equality that keeps `bool`, `int` and `str` apart.
+
+    `True == 1` and `False == 0` in Python, so a plain `==` would let a criterion declaring
+    `equals: true` be satisfied by an output of `1`, and one declaring `equals: 1` be satisfied by
+    `True`. A criterion says which of those it means, and a run that reported the other one has
+    not met it.
+    """
+
+    if isinstance(expected, bool) or isinstance(value, bool):
+        return isinstance(value, bool) and isinstance(expected, bool) and value is expected
+    if isinstance(expected, str) or isinstance(value, str):
+        return isinstance(value, str) and isinstance(expected, str) and value == expected
+    return isinstance(value, int) and value == expected
 
 
 def read_path(value: Mapping[str, Any], path: str) -> Any:

--- a/packages/core/tests/test_campaign.py
+++ b/packages/core/tests/test_campaign.py
@@ -311,3 +311,101 @@ def test_an_optimizer_may_still_spell_the_contract_in_python() -> None:
     assert Suggestion.model_validate({"parameters": {"x": 1}, "acquisitionFunction": "qEI"}) == (
         suggestion
     )
+
+
+def test_a_criterion_that_is_not_a_measurement_can_be_declared() -> None:
+    """A solver either converged or it did not, and `lower`/`upper` cannot say that at all.
+
+    `as_number` rejects `bool` on the correct ground that a `bool` is an `int` in Python and is
+    not a measurement, so before `equals` the whole class of yes-or-no criteria — converged,
+    trusted, in-spec — was inexpressible in a stored campaign and had to be recast as a number by
+    whatever parsed the code's output. That moved the criterion into the adapter, which is the one
+    place a declared criterion is not allowed to live.
+    """
+
+    converged = OutcomeConstraint(name="scf", output="scf.converged", equals=True)
+    assert converged.violation({"scf": {"converged": True}}) is None
+    assert converged.violation({"scf": {"converged": False}}) == (
+        "scf: scf.converged=False is not True"
+    )
+
+    # The instrument-quality case from audit finding A3: a vocabulary that could not express a bad
+    # measurement. `degraded` is now a recorded, excluded observation rather than a failed run.
+    trusted = OutcomeConstraint(name="quality", output="quality", equals="ok")
+    assert trusted.violation({"quality": "ok"}) is None
+    assert trusted.violation({"quality": "degraded"}) == "quality: quality='degraded' is not 'ok'"
+
+    # An absent output is still "feasibility cannot be established", not "does not equal".
+    assert converged.violation({}) == (
+        "scf: the run reported no scf.converged, so feasibility cannot be established"
+    )
+
+
+def test_an_exact_criterion_does_not_confuse_a_bool_with_the_number_it_equals() -> None:
+    """`True == 1` in Python, so `==` would make these two criteria satisfy each other.
+
+    A run reporting `1` has not reported that it converged, and a run reporting `True` has not
+    reported a count of one. Replacing `matches_exactly` with `==` turns both of these green.
+    """
+
+    converged = OutcomeConstraint(name="scf", output="flag", equals=True)
+    assert converged.violation({"flag": 1}) == "scf: flag=1 is not True"
+    assert converged.violation({"flag": 1.0}) == "scf: flag=1.0 is not True"
+
+    counted = OutcomeConstraint(name="cycles", output="flag", equals=1)
+    assert counted.violation({"flag": True}) == "cycles: flag=True is not 1"
+    assert counted.violation({"flag": 1}) is None
+
+    # A string is not the number or the flag that prints the same way.
+    labelled = OutcomeConstraint(name="label", output="flag", equals="1")
+    assert labelled.violation({"flag": 1}) == "label: flag=1 is not '1'"
+    assert labelled.violation({"flag": "1"}) is None
+
+
+def test_an_outcome_criterion_that_could_never_be_met_is_refused_at_load() -> None:
+    """Each of these is a declaration error, and each was accepted before.
+
+    A constraint that bounds nothing was already refused. Declaring a bound *and* an exact value
+    left it ambiguous which one applied, and an inverted interval is satisfied by no run at all —
+    both were accepted, and both fail every candidate silently once the campaign is running.
+    """
+
+    with pytest.raises(PydanticValidationError, match="bounds nothing"):
+        OutcomeConstraint(name="empty", output="pressure")
+    with pytest.raises(PydanticValidationError, match="a criterion is one or the other"):
+        OutcomeConstraint(name="both", output="pressure", upper=9.0, equals=True)
+    with pytest.raises(PydanticValidationError, match="empty interval"):
+        OutcomeConstraint(name="inverted", output="pressure", lower=9.0, upper=5.0)
+
+    # The bounded forms this must not have broken.
+    assert OutcomeConstraint(name="ok", output="pressure", lower=5.0, upper=9.0).upper == 9.0
+    assert OutcomeConstraint(name="point", output="pressure", lower=5.0, upper=5.0).lower == 5.0
+
+
+def test_an_exact_criterion_survives_the_serialised_form_a_campaign_is_stored_as() -> None:
+    """The point of a declared criterion is that it can be written down and read back.
+
+    A criterion that only exists as a Python object is the adapter-supplied callable this contract
+    exists to avoid, so `equals` is only useful if it round-trips through the stored document with
+    its type intact — `true` must not come back as `1`.
+    """
+
+    definition = CampaignDefinition(
+        id="campaign.dft",
+        name="Converged energies only",
+        objective="minimize energy",
+        workflow_id="relax",
+        optimizer="grid",
+        outcome_constraints=[
+            OutcomeConstraint(name="scf", output="scf.converged", equals=True),
+            OutcomeConstraint(name="quality", output="quality", equals="ok"),
+            OutcomeConstraint(name="pressure", output="pressure", upper=9.0),
+        ],
+    )
+
+    restored = CampaignDefinition.model_validate_json(definition.model_dump_json())
+    assert restored == definition
+    exact = restored.outcome_constraints[0].equals
+    assert exact is True and isinstance(exact, bool)
+    assert restored.outcome_constraints[1].equals == "ok"
+    assert restored.problem().outcome_constraints[0].violation({"scf": {"converged": False}})

--- a/packages/runtime/tests/test_campaign.py
+++ b/packages/runtime/tests/test_campaign.py
@@ -67,6 +67,7 @@ PROBE_OUTPUT_SCHEMA: dict[str, Any] = {
         "cost": {"type": "number"},
         "sigma": {"type": "number"},
         "pressure": {"type": "number"},
+        "converged": {"type": "boolean"},
     },
 }
 
@@ -154,6 +155,8 @@ class ScoreAdapter(CapabilityAdapter):
                     "cost": 10.0 - value,
                     "sigma": round(0.1 * value, 6),
                     "pressure": 2.0 * value,
+                    # A yes-or-no fact about the run, not a measurement of it.
+                    "converged": value >= 2.0,
                 },
             )
         finally:
@@ -218,6 +221,7 @@ def probe_workflow(
             "cost": "${steps.score.output.cost}",
             "sigma": "${steps.score.output.sigma}",
             "pressure": "${steps.score.output.pressure}",
+            "converged": "${steps.score.output.converged}",
         },
     )
 
@@ -1036,6 +1040,49 @@ async def test_a_declared_candidate_constraint_is_enforced_before_the_run(tmp_pa
     assert "fractions-sum-to-one" in (result.history[0].error or "")
     assert result.history[1].status is CampaignObservationStatus.SUCCEEDED
     assert [call["x"] for call in adapter.calls] == [0.25]
+
+
+@pytest.mark.asyncio
+async def test_a_yes_or_no_criterion_excludes_a_run_the_same_way_a_bound_does(tmp_path) -> None:
+    """A campaign whose gate is "did it converge" must behave exactly like one whose gate is a bound.
+
+    This is the criterion the numeric-only contract could not state, and stating it is only half
+    the work: the observation still has to reach the record with its numbers intact, still has to
+    be kept out of the best and away from the target, and still must not fail the run. A run that
+    did not converge produced real data about a candidate that does not converge.
+    """
+
+    adapter = ScoreAdapter()
+    runner, repositories = build_campaign(tmp_path, adapter)
+
+    result = await runner.run(
+        probe_workflow(),
+        ScriptedOptimizer([[{"x": 1.0}, {"x": 3.0}]]),
+        environment="simulation",
+        operator_id="operator/alice",
+        max_iterations=2,
+        batch_size=2,
+        objectives=objectives_for("score"),
+        outcome_constraints=[OutcomeConstraint(name="converged", output="converged", equals=True)],
+        target_score=2.0,
+    )
+
+    # x=1.0 did not converge; the run succeeded and the datum is kept.
+    unconverged = result.history[0]
+    assert unconverged.status is CampaignObservationStatus.SUCCEEDED
+    assert unconverged.score == 1.0
+    assert not unconverged.feasible
+    assert "converged" in " ".join(unconverged.constraint_violations)
+
+    # x=3.0 converged, so it is the only candidate that can win.
+    assert result.history[1].feasible
+    assert result.best is not None and result.best.candidate == {"x": 3.0}
+    # An infeasible observation cannot reach the target, so the campaign runs out of iterations.
+    assert result.stop_reason is CampaignStopReason.MAX_ITERATIONS
+
+    record = CampaignReader(repositories).get(result.campaign_id)
+    assert record.iterations[0].feasible is False
+    assert record.best is not None and record.best.iteration == 1
 
 
 @pytest.mark.asyncio

--- a/packages/schemas/jsonschema/campaign-problem.schema.json
+++ b/packages/schemas/jsonschema/campaign-problem.schema.json
@@ -143,6 +143,24 @@
           "default": null,
           "title": "Upper"
         },
+        "equals": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Equals"
+        },
         "description": {
           "default": "",
           "title": "Description",

--- a/packages/schemas/jsonschema/campaign.schema.json
+++ b/packages/schemas/jsonschema/campaign.schema.json
@@ -143,6 +143,24 @@
           "default": null,
           "title": "Upper"
         },
+        "equals": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Equals"
+        },
         "description": {
           "default": "",
           "title": "Description",


### PR DESCRIPTION
Closes the sharpest half of the residual gap in audit finding A3 (restated in #12).

## The gap

`OutcomeConstraint` offered `lower` and `upper` and nothing else, so every acceptance criterion had to be a number. `as_number` (`packages/core/src/opensdl_core/campaign.py:699`) rejects `bool` on the correct ground that a `bool` is an `int` in Python and is not a measurement — but nothing was put beside it. That left the whole class of yes-or-no criteria inexpressible: *did the solver converge*, *does the instrument trust this datum*, *is the sample in spec*.

Each had to be recast as a number by whatever parsed the code output, which moves the criterion into the adapter and out of the stored document. A criterion that only exists as adapter code is precisely the arbitrary callable this contract exists to avoid — it cannot be stored, sent over an interface, or read back.

This is also the vocabulary A3 says cannot express a bad measurement: the showcase declares `"quality": {"enum": ["ok"]}`, so an instrument reporting `degraded` fails schema validation and fails the run, instead of being recorded and quarantined.

## The change

`equals` states an exact value. Floats are deliberately excluded — exact equality on a measured quantity is almost never the intended criterion, and `lower` with `upper` says the intended thing.

Exact values keep their type. `True == 1` in Python, so a plain `==` would let a criterion declaring `true` be satisfied by a run reporting `1`, and one declaring `1` be satisfied by `True`.

Two declaration errors are now refused at load rather than failing every run in silence: a bound and an exact value on one constraint (ambiguous which applies), and an interval whose lower bound exceeds its upper (satisfiable by no run). `CandidateConstraint` already refused the second; `OutcomeConstraint` did not.

**Semantics are unchanged.** A violating observation is still recorded with its numbers intact, still handed to the optimizer as evidence about a candidate that does not satisfy the criterion, still excluded from the best and from reaching a target, and still not a failed run.

## What each check has to see in order to fail

Every test was confirmed failing first, against the named mutation:

| Test | Mutation it catches | Confirmed |
|---|---|---|
| `...does_not_confuse_a_bool_with_the_number_it_equals` | `matches_exactly` → `==` | fails |
| `...could_never_be_met_is_refused_at_load` | either validator branch removed | fails on each |
| `test_a_yes_or_no_criterion_excludes_a_run_the_same_way_a_bound_does` | `equals` ignored at evaluation | fails |

The end-to-end test drives the real runner: a probe that reports `converged` as a boolean, one candidate that does and one that does not, asserting the unconverged run succeeds, keeps its score, is excluded from best, does not reach the target, and lands in the campaign record as `feasible: false`.

## Scope

Additive and two-way. Schemas regenerated; `campaign` and `campaign-problem` gain the optional field. Guide and CHANGELOG updated.

`make lint`, `make test` (609 passed, was 604), `make docs`, `make example` all pass.