### PR TITLE
Let one caller hold a resource, not several

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,13 @@ workspace has carried, not artifacts anyone can install. See
 
 ### Changed
 
+- a resource lease is taken by a write whose own `WHERE` decides whether it may be taken, so two
+  callers can no longer both be told they hold one instrument. Acquisition read every resource and
+  then wrote every resource, and another caller fits between those steps: against that code, six
+  contenders racing for one expired lease were granted it four or five at a time, on every run of
+  ten. The row recorded one holder while the others proceeded believing they were alone. Losing the
+  race now reaches the caller as `False` rather than as an integrity error, and a refused set leaves
+  no partial claim behind;
 - the long-form documents left the repository root for the published site. `ARCHITECTURE.md`,
   `DEVELOPMENT.md`, `ROADMAP.md`, `VALIDATION.md` and `IMPORT_PROVENANCE.md` are now
   `docs/architecture/overview.md`, `docs/development/index.md`, `docs/development/roadmap.md`,

--- a/packages/storage/AGENTS.md
+++ b/packages/storage/AGENTS.md
@@ -3,4 +3,7 @@
 - All metadata access goes through `Repositories` or a future narrow protocol.
 - Model changes require Alembic migration and round-trip tests.
 - Artifact bytes are immutable and hash-verified.
-- Test SQLite locally and PostgreSQL in CI for dialect-specific behavior.
+- Test against SQLite. No PostgreSQL runs anywhere in CI, so dialect-specific behavior — the
+  rowcount of a conditional `UPDATE`, savepoints, conflict handling — is unverified on the other
+  supported backend. Prefer portable constructs and say in the change where one is relied on.
+  Adding that CI job is tracked in the development backlog.

--- a/packages/storage/src/opensdl_storage/repositories.py
+++ b/packages/storage/src/opensdl_storage/repositories.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import Any, Iterable
 
-from sqlalchemy import CursorResult, delete, select, update
+from sqlalchemy import CursorResult, delete, insert, or_, select, update
+from sqlalchemy.exc import IntegrityError
 
 from opensdl_core import (
     STARTABLE_RUN_STATES,
@@ -276,24 +277,62 @@ class Repositories:
             ]
 
     def acquire_leases(self, resource_ids: list[str], holder_id: str, ttl_seconds: float) -> bool:
+        """Hold every named resource, or none of them.
+
+        Each lease is taken by a write whose own `WHERE` decides whether it may be taken, so the
+        database settles the question rather than this process. Checking every resource and then
+        writing every resource, as this did, is two steps another holder fits between: two callers
+        both read a lease as expired, both take it, and both are told they hold it. The row records
+        one of them and the other drives the same instrument believing it is alone.
+
+        Resources are claimed in sorted order so that two callers wanting overlapping sets contend
+        over the same resource first and cannot deadlock holding halves of each other's set.
+        """
+
         if not resource_ids:
             return True
         now = datetime.now(UTC)
         expires = now + timedelta(seconds=ttl_seconds)
         with self.database.session() as session:
             for resource_id in sorted(set(resource_ids)):
-                row = session.get(LeaseRow, resource_id)
-                if row and self._aware(row.expires_at) > now and row.holder_id != holder_id:
+                if not self._claim_lease(session, resource_id, holder_id, now, expires):
+                    # All or nothing: a caller told it does not hold the set must hold no part of it.
+                    session.rollback()
                     return False
-            for resource_id in sorted(set(resource_ids)):
-                row = session.get(LeaseRow, resource_id)
-                if row is None:
-                    session.add(
-                        LeaseRow(resource_id=resource_id, holder_id=holder_id, expires_at=expires)
+        return True
+
+    @staticmethod
+    def _claim_lease(
+        session: Any, resource_id: str, holder_id: str, now: datetime, expires: datetime
+    ) -> bool:
+        """Take one lease, reporting whether it was taken. Never raises on contention."""
+
+        taken = session.execute(
+            update(LeaseRow)
+            .where(
+                LeaseRow.resource_id == resource_id,
+                # Free to take when it has run out, or when it is already ours to renew.
+                or_(LeaseRow.expires_at <= now, LeaseRow.holder_id == holder_id),
+            )
+            .values(holder_id=holder_id, expires_at=expires)
+        ).rowcount
+        if taken:
+            return True
+        # Nothing matched: either no row exists yet, or a live lease belongs to someone else. The
+        # insert distinguishes them without a second read — the primary key refuses the live one,
+        # and refuses a concurrent insert of the same resource, which is the same answer.
+        try:
+            with session.begin_nested():
+                session.execute(
+                    insert(LeaseRow).values(
+                        resource_id=resource_id,
+                        holder_id=holder_id,
+                        expires_at=expires,
+                        created_at=now,
                     )
-                else:
-                    row.holder_id = holder_id
-                    row.expires_at = expires
+                )
+        except IntegrityError:
+            return False
         return True
 
     def release_leases(self, holder_id: str) -> None:

--- a/packages/storage/tests/test_storage.py
+++ b/packages/storage/tests/test_storage.py
@@ -1,3 +1,4 @@
+import threading
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -13,6 +14,7 @@ from opensdl_core import (
     TaskRecord,
     TaskState,
 )
+from opensdl_storage.db_models import LeaseRow
 from opensdl_storage import (
     ArtifactStore,
     Database,
@@ -215,3 +217,98 @@ def test_claiming_a_run_that_does_not_exist_reports_it(tmp_path) -> None:
 
     assert repo.start_run("run_absent") is None
     database.dispose()
+
+
+def _expired_lease(database, resource_id: str, holder_id: str) -> None:
+    """Leave `resource_id` holding a lease that has already run out."""
+
+    with database.session() as session:
+        session.add(
+            LeaseRow(
+                resource_id=resource_id,
+                holder_id=holder_id,
+                expires_at=datetime.now(UTC) - timedelta(seconds=60),
+            )
+        )
+
+
+def test_a_lease_that_has_run_out_goes_to_exactly_one_of_the_callers_racing_for_it(
+    tmp_path,
+) -> None:
+    """Two holders of one instrument is the failure this lease exists to prevent.
+
+    Acquisition used to read every resource and then write every resource. Between those two
+    steps another caller fits: both read the lease as expired, both take it, and both are told
+    they hold it. The row records one of them; the other drives the same instrument believing it
+    is alone. Against that implementation this test granted four or five of six callers on every
+    run of ten, so it is not a probabilistic guard — it is the defect, reproduced.
+
+    A file-backed store is required: `sqlite:///:memory:` gives each connection its own database,
+    so the callers would not contend at all and this would pass against anything.
+    """
+
+    database = Database(f"sqlite:///{tmp_path / 'lab.db'}")
+    database.initialize()
+    _expired_lease(database, "balance", "the-holder-that-timed-out")
+
+    contenders = 6
+    ready = threading.Barrier(contenders, timeout=30)
+    outcomes: dict[str, object] = {}
+
+    def contend(holder_id: str) -> None:
+        repositories = Repositories(Database(f"sqlite:///{tmp_path / 'lab.db'}"))
+        ready.wait()
+        try:
+            outcomes[holder_id] = repositories.acquire_leases(["balance"], holder_id, 60)
+        except Exception as exc:  # noqa: BLE001 - the point is that nothing escapes
+            outcomes[holder_id] = f"{type(exc).__name__}: {exc}"
+
+    threads = [
+        threading.Thread(target=contend, args=(f"task-{index}",)) for index in range(contenders)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(30)
+
+    granted = [holder for holder, result in outcomes.items() if result is True]
+    assert len(granted) == 1, outcomes
+    # Losing a race is an answer, not an error: contention must reach the caller as `False`.
+    assert [result for result in outcomes.values() if isinstance(result, str)] == []
+    assert sorted(outcomes.values(), key=repr) == sorted([True] + [False] * 5, key=repr)
+
+
+def test_a_lease_is_taken_whole_or_not_at_all(tmp_path) -> None:
+    """A caller told it does not hold the set must hold no part of it.
+
+    Claiming resource by resource means the refusal can arrive with earlier claims already
+    written. Leaving those behind would strand an instrument nobody is using and nobody released,
+    until its lease ran out. Removing the rollback turns the last assertion here red.
+    """
+
+    database, repositories = build_repository(tmp_path)
+    assert repositories.acquire_leases(["mixer"], "task-incumbent", 60)
+
+    # `balance` sorts first, so it is claimed before `mixer` refuses the set.
+    assert not repositories.acquire_leases(["balance", "mixer"], "task-latecomer", 60)
+
+    # `balance` must be free for the next caller, and the incumbent must still hold `mixer`.
+    assert repositories.acquire_leases(["balance"], "task-third-party", 60)
+    assert not repositories.acquire_leases(["mixer"], "task-third-party", 60)
+
+
+def test_a_lease_is_refused_while_live_taken_over_once_expired_and_renewed_by_its_holder(
+    tmp_path,
+) -> None:
+    """The three answers the conditional write has to give, stated one at a time."""
+
+    database, repositories = build_repository(tmp_path)
+
+    assert repositories.acquire_leases(["balance"], "task-a", 60)
+    assert not repositories.acquire_leases(["balance"], "task-b", 60)
+    # Its own holder renews rather than refusing itself.
+    assert repositories.acquire_leases(["balance"], "task-a", 60)
+
+    _expired_lease(database, "colorimeter", "task-departed")
+    assert repositories.acquire_leases(["colorimeter"], "task-c", 60)
+    assert not repositories.acquire_leases(["colorimeter"], "task-d", 60)


### PR DESCRIPTION
A concurrency defect in resource leasing, found by asking what `acquire_leases` would have to see in order to fail. It is safety-adjacent: the failure mode is two runs both believing they hold one instrument.

## The defect, reproduced

Acquisition read every resource and then wrote every resource. Another caller fits between those two steps — both read a lease as expired, both take it, both are told they hold it. The row records one of them; the other drives the same instrument believing it is alone.

Six contenders racing for one expired lease against the previous implementation:

```
trial 0: granted=5   trial 5: granted=5
trial 1: granted=4   trial 6: granted=4
trial 2: granted=2   trial 7: granted=5
trial 3: granted=4   trial 8: granted=5
trial 4: granted=4   trial 9: granted=2
TRIALS WITH MULTIPLE HOLDERS: 10 /10
```

The fresh-lease path was saved by the primary key, but surfaced contention as an `IntegrityError` escaping to the caller rather than as `False`. The takeover path — an expired lease, where a row already exists and both callers take the `UPDATE` branch — had no such protection.

Reachable today: the API application and a CLI campaign are two processes over one store.

## The fix

Each lease is taken by a conditional `UPDATE` whose `WHERE` admits only a lease that has run out or is already ours to renew, falling back to an `INSERT` whose primary key refuses both a live foreign lease and a concurrent insert of the same resource. The database settles the question rather than this process, so the bound holds across controllers — the same reasoning `start_run` already applies to claiming a run.

Because resources are now claimed one at a time, a refused set could leave earlier claims committed; an explicit rollback keeps acquisition all-or-nothing.

## What each check has to see in order to fail

| Test | Mutation | Result |
|---|---|---|
| `...goes_to_exactly_one_of_the_callers_racing_for_it` | the original check-then-act | fails 3/3 |
| `test_a_lease_is_taken_whole_or_not_at_all` | rollback removed | fails |

The race test needs a file-backed store — `sqlite:///:memory:` gives each connection its own database, so the callers would not contend and it would pass against anything. **Flakiness measured: 0 failures in 20 consecutive runs** against this implementation, and it failed on every attempt against the old one.

## One thing found on the way

`packages/storage/AGENTS.md` instructed: *"Test SQLite locally and PostgreSQL in CI for dialect-specific behavior."* Nothing in the workflows, tests, or Makefile mentions PostgreSQL at all — and this change leans on rowcount from a conditional update, savepoints, and conflict handling, all of which are portable in principle and verified only on SQLite in practice. The instruction now says what is true rather than what was intended. The audit already records the gap and the backlog already tracks adding the job, so nothing new is created here.

`make lint`, `make test` (607 passed), `make docs`, `make example` all pass.