### PR TITLE
Make a lease last as long as the task it protects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,11 @@ workspace has carried, not artifacts anyone can install. See
   ten. The row recorded one holder while the others proceeded believing they were alone. Losing the
   race now reaches the caller as `False` rather than as an integrity error, and a refused set leaves
   no partial claim behind;
+- a resource lease lasts as long as the task it protects may run, rather than for a configured TTL
+  chosen without reference to the work. A step slower than that TTL left its instrument reclaimable
+  while it was still being driven, so a second task could take it with no race and no contention
+  involved — one other task starting was enough. The lease now covers every attempt the retry loop
+  may make and the backoff between them, and the configured TTL is a floor rather than a ceiling;
 - the long-form documents left the repository root for the published site. `ARCHITECTURE.md`,
   `DEVELOPMENT.md`, `ROADMAP.md`, `VALIDATION.md` and `IMPORT_PROVENANCE.md` are now
   `docs/architecture/overview.md`, `docs/development/index.md`, `docs/development/roadmap.md`,

--- a/docs/development/audit-2026-08-05.md
+++ b/docs/development/audit-2026-08-05.md
@@ -329,6 +329,52 @@ left, and it should be settled together with intervention acknowledgement rather
 
 ---
 
+### A7 — Losing a resource race stops the campaign and blames the science · M
+
+*Found 2026-08-10, reproduced, not fixed: the fix is a choice between several defensible stop
+semantics and belongs to the maintainer.*
+
+A campaign records a lease failure as a failed iteration, which is deliberate and tested — "a lease
+failure is a laboratory fact and not a framework error". What is not deliberate is what that failure
+then does. Every non-succeeding observation increments `consecutive_failures`, and reaching
+`max_consecutive_failures` (default 3) stops the campaign with `FAILURE_LIMIT` and the detail *"the
+failure is systematic rather than routine"*.
+
+A laboratory that declares more parallelism than it has exclusive instruments produces a loser in
+every batch. Four candidates, `max_parallel_runs=4`, one exclusive instrument, defaults otherwise:
+
+```
+stop_reason : failure_limit
+stop_detail : 3 consecutive iterations failed, so the failure is systematic rather than routine;
+              last error: resources busy: ['probe-bench']
+successes   : 1 [{'x': 1.0}]
+candidates never evaluated: [{'x': 2.0}, {'x': 3.0}, {'x': 4.0}]
+```
+
+The campaign stops on its first batch having measured one of eight candidates. Nothing was wrong
+with the instrument, the chemistry, or the seven candidates it never evaluated; the laboratory was
+asked to run four things at once and can run one. Unattended operation is the point of the loop, and
+this ends it on the first batch while naming a cause an operator will go looking for in the wrong
+place.
+
+Two consequences beyond the early stop:
+
+- **A candidate is recorded as a failed evaluation it never received.** `_ESTABLISHED_RUN_STATES`
+  includes `FAILED`, so a resume reads the outcome off that run rather than re-dispatching, and a
+  parameter point that lost a race is never measured.
+- **The optimizer is told the candidate failed.** It is evidence about the laboratory's schedule,
+  offered as evidence about the parameter point.
+
+The fix is not obvious, which is why this records rather than changes it. Simply not counting
+contention toward the limit risks a campaign that never stops when a resource is held by something
+outside the campaign entirely. Counting a batch rather than an observation — systematic means *no*
+candidate in a batch got through — keeps a stop condition while letting a partly-served batch
+continue. Re-queuing the loser instead of recording a failure is the most correct and the largest.
+Scheduling around the lease removes the contention rather than interpreting it, and is the honest
+end state. Backlog §4 already tracks the scheduling half.
+
+---
+
 ---
 
 ## B. The closed loop is not a contract

--- a/docs/development/audit-2026-08-05.md
+++ b/docs/development/audit-2026-08-05.md
@@ -306,6 +306,29 @@ flight and reports success. The same happens on API startup (`apps/api/src/opens
 Only `.agents/skills/orient-lab/SKILL.md` step 6 warns of this — nothing in `--help`, the reference
 docs, or the code.
 
+### A6 — A timed-out task releases its instrument while saying the equipment may still be moving · M
+
+*Found 2026-08-10, while fixing the lease bound. Not addressed, because the fix depends on a
+mechanism that does not exist.*
+
+The timeout path records, in its own words, that the runtime "stopped waiting; it did not stop the
+equipment, and nothing reported an outcome, so the physical outcome is unknown", moves the task to
+`INTERVENTION_REQUIRED`, and states that "a person must establish what the equipment did before this
+run continues". The `finally` around the retry loop then calls `release_leases(task.id)`
+unconditionally, so the instrument that may still be moving is immediately available to the next
+task that asks for it.
+
+The reasoning and the resource behaviour contradict each other: the record says a person must
+establish what the equipment is doing, and the lease says anyone may now command it.
+
+The obvious fix — hold the lease until the intervention is acknowledged — needs an acknowledgement
+operation, and there is none; `INTERVENTION_REQUIRED` is terminal for everything, which Backlog §4
+already tracks. Holding the lease with no way to release it would strand the instrument until the
+lease expired, which is a different wrong answer rather than a better one. So this is recorded and
+left, and it should be settled together with intervention acknowledgement rather than before it.
+
+---
+
 ---
 
 ## B. The closed loop is not a contract

--- a/packages/runtime/src/opensdl_runtime/engine.py
+++ b/packages/runtime/src/opensdl_runtime/engine.py
@@ -70,6 +70,22 @@ def may_repeat_after(definition: CapabilityDefinition, failure: BaseException) -
     return False
 
 
+#: Retry backoff, doubling from this and capped below.
+RETRY_BACKOFF_SECONDS = 0.05
+RETRY_BACKOFF_CAP_SECONDS = 1.0
+
+
+def _retry_backoff_seconds(attempt: int) -> float:
+    """How long the runtime waits before the attempt after this one.
+
+    One definition, used both to wait and to size the resource lease that has to cover the
+    waiting. Two copies of it would let the lease silently stop covering the retry loop the
+    moment either changed.
+    """
+
+    return min(RETRY_BACKOFF_SECONDS * (2**attempt), RETRY_BACKOFF_CAP_SECONDS)
+
+
 class ReferenceRuntime:
     """Small, durable workflow runtime used by local deployments and conformance tests."""
 
@@ -325,6 +341,23 @@ class ReferenceRuntime:
             )
         return replaced
 
+    def _lease_seconds_for(self, timeout: float, max_retries: int) -> float:
+        """How long this task's resource lease has to last.
+
+        A lease shorter than the work it protects becomes reclaimable while that work is still
+        running, and the instrument then has two holders — the failure the lease exists to
+        prevent, reached with no race at all and no concurrency beyond one other task starting.
+        The configured TTL is a floor rather than a ceiling: the lease covers every attempt the
+        retry loop may make and the backoff between them.
+
+        What this bounds is how long the *runtime* may hold the task, which is the only quantity
+        it knows. An instrument still moving after the runtime stopped waiting is a different
+        problem; the timeout path records it and this does not solve it.
+        """
+
+        backoff = sum(_retry_backoff_seconds(attempt) for attempt in range(max_retries))
+        return max(self.lease_ttl_seconds, (max_retries + 1) * timeout + backoff)
+
     def _emit_superseded(
         self,
         superseded: RunRecord,
@@ -501,13 +534,6 @@ class ReferenceRuntime:
             task.state = TaskState.WAITING_FOR_RESOURCES
             task.updated_at = utc_now()
             self.repositories.upsert_task(task)
-            if not self.repositories.acquire_leases(resources, task.id, self.lease_ttl_seconds):
-                task.state = TaskState.FAILED
-                task.error = f"resources busy: {resources}"
-                task.updated_at = utc_now()
-                self.repositories.upsert_task(task)
-                raise ResourceBusyError(task.error)
-
             max_retries = step.retries if step.retries is not None else definition.max_retries
             # What this timeout bounds is how long the runtime waits, and nothing else. Adapter
             # code runs on its own thread and loop so that the bound holds even for a blocking
@@ -519,6 +545,14 @@ class ReferenceRuntime:
             timeout = (
                 step.timeout_seconds or definition.timeout_seconds or self.default_timeout_seconds
             )
+            if not self.repositories.acquire_leases(
+                resources, task.id, self._lease_seconds_for(timeout, max_retries)
+            ):
+                task.state = TaskState.FAILED
+                task.error = f"resources busy: {resources}"
+                task.updated_at = utc_now()
+                self.repositories.upsert_task(task)
+                raise ResourceBusyError(task.error)
             request = ExecutionRequest(
                 capability_id=step.capability,
                 inputs=resolved_inputs,
@@ -664,7 +698,7 @@ class ReferenceRuntime:
                             raise
                         task.state = TaskState.RETRYING
                         self.repositories.upsert_task(task)
-                        await asyncio.sleep(min(0.05 * (2**attempt), 1.0))
+                        await asyncio.sleep(_retry_backoff_seconds(attempt))
                         continue
 
                     # The adapter reported completion, so the physical action has happened. A

--- a/packages/runtime/tests/test_runtime.py
+++ b/packages/runtime/tests/test_runtime.py
@@ -1616,3 +1616,77 @@ async def test_run_started_records_the_operator_that_submitted_it(tmp_path) -> N
         "operator/bob",
     ]
     assert repositories.get_run(failed.id).operator_id == "operator/alice"  # type: ignore[union-attr]
+
+
+async def test_a_resource_stays_leased_for_as_long_as_the_task_may_run(tmp_path) -> None:
+    """A task must not outlive the lease protecting the instrument it is driving.
+
+    The lease was taken for the configured TTL regardless of how long the task could take, so a
+    step slower than that TTL left its instrument reclaimable while it was still running. Two
+    holders of one instrument is the failure a lease exists to prevent, and this route needs no
+    race and no contention — one other task starting is enough.
+
+    Here the lease is configured at a fifth of a second and the work takes two, so the check a
+    second later falls well after the configured TTL would have expired and well before the task
+    finishes. Against the previous implementation the second holder is granted.
+    """
+
+    database = Database(f"sqlite:///{tmp_path / 'lab.db'}")
+    database.initialize()
+    repositories = Repositories(database)
+    repositories.upsert_resource(Resource(id="bench", name="Bench", type="simulator"))
+    registry = CapabilityRegistry()
+    registry.register(AwaitingAdapter(seconds=2.0))
+    runtime = ReferenceRuntime(
+        registry,
+        repositories,
+        PolicyEngine(default_effect="allow"),
+        LocalArtifactStore(tmp_path / "artifacts", repositories),
+        lease_ttl_seconds=0.2,
+        default_timeout_seconds=30.0,
+    )
+    workflow = WorkflowDefinition(
+        id="slow-workflow",
+        name="Slower than its lease",
+        input_schema={"type": "object"},
+        steps=[WorkflowStep(id="slow", capability="test.awaiting", inputs={}, resources=["bench"])],
+        outputs={},
+    )
+
+    running = asyncio.create_task(
+        runtime.run_workflow(workflow, {}, operator_id="operator/a", environment="simulation")
+    )
+    await asyncio.sleep(1.0)
+    # A separate connection, as a second controller would be.
+    contender = Repositories(Database(f"sqlite:///{tmp_path / 'lab.db'}"))
+    assert not contender.acquire_leases(["bench"], "a-different-task", 60)
+
+    run = await running
+    assert run.state is RunState.COMPLETED
+    # And the lease is released once the work is actually done, not merely once the TTL elapsed.
+    assert contender.acquire_leases(["bench"], "a-different-task", 60)
+
+
+def test_the_lease_covers_every_attempt_the_retry_loop_may_make(tmp_path) -> None:
+    """Retries run inside one lease, so the bound is per task and not per attempt.
+
+    Sizing the lease from a single attempt would leave it short by the retries and the backoff
+    between them, which is the same defect arriving by a slower route.
+    """
+
+    database = Database("sqlite:///:memory:")
+    database.initialize()
+    runtime = ReferenceRuntime(
+        CapabilityRegistry(),
+        Repositories(database),
+        PolicyEngine(default_effect="allow"),
+        LocalArtifactStore(tmp_path, Repositories(database)),
+        lease_ttl_seconds=1.0,
+    )
+
+    # The configured TTL is a floor: short work keeps it.
+    assert runtime._lease_seconds_for(timeout=0.1, max_retries=0) == 1.0
+    # Four attempts of ten seconds cannot be covered by a one-second lease.
+    assert runtime._lease_seconds_for(timeout=10.0, max_retries=3) >= 40.0
+    # The backoff between attempts is inside the lease too, so the bound exceeds the work alone.
+    assert runtime._lease_seconds_for(timeout=10.0, max_retries=3) > 40.0


### PR DESCRIPTION
A second defect in the resource-lease path, in the same seam as #14 and independent of it. #14 fixed *how* a lease is taken; this fixes *how long* it lasts.

## The defect

The lease was taken for a configured TTL chosen without reference to the work it covers. A step slower than that TTL left its instrument reclaimable while it was still being driven.

Unlike #14 this needs **no race and no contention** — one other task starting is enough, and the result is deterministic:

```
lease_ttl_seconds=0.5, adapter runs for 2.0s, checked at 1.2s
SECOND HOLDER GRANTED WHILE FIRST STILL RUNNING: True
first task finished: completed          # unaware it had lost the instrument
```

The default configuration hides it — one attempt at 60s against a lease of 300s. But `step.timeout_seconds`, `definition.timeout_seconds`, and the retry loop all live inside a single lease, so `(retries + 1) x timeout` crosses 300s easily. Long-running compute jobs are entirely made of that case.

## The fix

`_lease_seconds_for(timeout, max_retries)` sizes the lease to cover every attempt the retry loop may make plus the backoff between them, with the configured TTL as a floor rather than a ceiling. Acquisition moved below the timeout/retries computation, which is a pure reordering.

Expiry keeps its purpose: a controller that never returns still releases the instrument, just not before the work it was protecting could have finished — which is the correct moment to reclaim it. Restart recovery is unaffected, since `recover_incomplete_runs` releases leases explicitly rather than waiting for expiry.

The backoff now has one definition, used both to wait and to size the lease. Two copies would let the lease quietly stop covering the retry loop the moment either changed.

## What each check has to see in order to fail

| Test | Mutation | Result |
|---|---|---|
| `test_a_resource_stays_leased_for_as_long_as_the_task_may_run` | lease sized from the configured TTL alone (the previous behaviour) | fails |
| `test_the_lease_covers_every_attempt_the_retry_loop_may_make` | bound sized per attempt rather than per task | fails |

The integration test uses a file-backed store and a second `Repositories` connection, as a second controller would. It also asserts the lease *is* released once the work finishes, so the fix cannot degenerate into holding leases forever.

## Recorded, not fixed: audit finding A6

The timeout path states that the runtime "did not stop the equipment... a person must establish what the equipment did before this run continues", then releases the lease unconditionally in its `finally`. The record says a person must establish what the instrument is doing; the lease says anyone may now command it.

Holding it instead needs an acknowledgement operation, and there is none — `INTERVENTION_REQUIRED` is terminal for everything, which Backlog §4 already tracks. Stranding the instrument until expiry is a different wrong answer, not a better one. So A6 records it for settlement together with intervention acknowledgement.

`make lint`, `make test` (606 passed), `make docs`, `make example` all pass.