### PR TITLE
Stop blaming the science when the bench was busy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,14 @@ workspace has carried, not artifacts anyone can install. See
 
 ### Changed
 
+- a campaign's consecutive-failure limit counts batches that completed nothing rather than every
+  observation that did not succeed. A laboratory declaring more parallelism than it has exclusive
+  instruments produces a loser in every batch, and counting those stopped the campaign on its first
+  batch reporting the failure as systematic rather than routine — four candidates against one
+  instrument measured one of eight and named a cause an operator would look for in the instrument
+  or the chemistry. A batch that completed nothing still counts every attempt in it, so a genuinely
+  failing laboratory stops exactly as promptly as before, and a campaign running one candidate at a
+  time is unchanged;
 - a resource lease is taken by a write whose own `WHERE` decides whether it may be taken, so two
   callers can no longer both be told they hold one instrument. Acquisition read every resource and
   then wrote every resource, and another caller fits between those steps: against that code, six

--- a/docs/development/audit-2026-08-05.md
+++ b/docs/development/audit-2026-08-05.md
@@ -24,6 +24,7 @@ and a finding that recurs is more informative than one that vanishes.
 | 2026-08-06 | B6 | The optimizer contract can express batch proposal, multiple objectives, declared constraints, a validated search space, uncertainty and acquisition provenance, without adding a required method. A decision is recorded before the run it causes and names the evidence it rested on. Batch execution is real and bounded by a laboratory-declared parallelism; the runner still does not schedule around a resource lease, which a test states rather than a comment. |
 | 2026-08-06 | B4, B7 | The optimizer contract lives in `opensdl-core`, so a third-party optimizer depends on a protocol and a few frozen models rather than on storage, policy, workflows and SQLAlchemy; the sole boundary exception is gone, and `CampaignDefinition` can declare what the runner accepts, checked in both directions. A campaign resumes from its own record: completed work is not repeated, iteration numbering continues, a second start under one identifier is refused, and a resume over a run whose physical outcome is unknown is refused rather than laundered. |
 | 2026-08-10 | A4 (blast radius), third instance of the A1/A2 class | Restart reconciliation asked "may this be repeated when nothing reported an outcome?" for itself instead of reading `retry_safety`, contradicting the timeout path in the same file. One helper, `may_repeat_without_outcome`, now serves every path that asks it without an outcome in hand. An interrupted task whose capability declares `repeatable` is recorded `FAILED` and resumes; every other declaration, and an unknown capability, still records `INTERVENTION_REQUIRED`. So a restart no longer permanently ends a campaign built from capabilities that had declared repeating harmless. A4's blast radius is bounded accordingly, and the `--help`, docstring, CLI reference and onboarding text that described the old unconditional behaviour are corrected. The other half is unchanged: no operation acknowledges an intervention, so `INTERVENTION_REQUIRED` remains terminal for everything else — still tracked in Backlog §4. |
+| 2026-08-10 | A7 | The consecutive-failure limit counts batches that completed nothing rather than observations that did not succeed, so a laboratory asked to run more at once than it owns no longer stops on its first batch reporting the failure as systematic. A batch that completed nothing still counts every attempt in it, so a genuinely failing laboratory stops as promptly as before, and `batch_size=1` is unchanged in every case. A6 remains open, and so does the larger half of A7: a candidate that lost a race is still recorded as a failed evaluation it never received. |
 | 2026-08-07 | Decision 4 (the C5 mutation case), B7 (remaining half) | `RunCreated` carries a canonical digest of the workflow document it captured and a resume must present the same document, so a non-terminal run can no longer be turned into a different execution under the original operator's name; `supersedes` mints a new run naming the one it replaces, recorded on both. Starting a run is one conditional write over the states the declared machine already permitted, so two callers can no longer both enter `run_workflow` on the same running run. `CampaignObservation`, `Suggestion` and `CampaignProblem` are typed models with generated schemas, and the hand-rolled serialisation whose keys matched nothing published is gone. |
 
 ## Decisions the owner has to make
@@ -329,10 +330,10 @@ left, and it should be settled together with intervention acknowledgement rather
 
 ---
 
-### A7 — Losing a resource race stops the campaign and blames the science · M
+### A7 — Losing a resource race stops the campaign and blames the science · M · **resolved**
 
-*Found 2026-08-10, reproduced, not fixed: the fix is a choice between several defensible stop
-semantics and belongs to the maintainer.*
+*Found and reproduced 2026-08-10; resolved the same day. The stop rule now counts batches that
+completed nothing rather than observations that did not succeed.*
 
 A campaign records a lease failure as a failed iteration, which is deliberate and tested — "a lease
 failure is a laboratory fact and not a framework error". What is not deliberate is what that failure
@@ -365,13 +366,24 @@ Two consequences beyond the early stop:
 - **The optimizer is told the candidate failed.** It is evidence about the laboratory's schedule,
   offered as evidence about the parameter point.
 
-The fix is not obvious, which is why this records rather than changes it. Simply not counting
-contention toward the limit risks a campaign that never stops when a resource is held by something
-outside the campaign entirely. Counting a batch rather than an observation — systematic means *no*
-candidate in a batch got through — keeps a stop condition while letting a partly-served batch
-continue. Re-queuing the loser instead of recording a failure is the most correct and the largest.
-Scheduling around the lease removes the contention rather than interpreting it, and is the honest
-end state. Backlog §4 already tracks the scheduling half.
+**Resolved by the second option.** "Systematic" now means a batch in which *nothing* completed. A
+batch that got a candidate through is a working laboratory, so the candidates that lost a race in it
+no longer count toward the limit. A batch that completed nothing still counts every attempt in it,
+so a genuinely failing laboratory stops exactly as promptly as before — three failed attempts,
+whether they arrive one batch at a time or all at once — and a campaign with `batch_size=1`, the
+default, behaves identically to before in every case. `_trailing_failures` reads the same way, so a
+resume cannot inherit a limit the running loop had already reset.
+
+Not counting contention at all was rejected: a resource held by something outside the campaign would
+leave the loop running forever with nothing to show. The two larger options remain open and are the
+honest end state rather than this one — re-queuing the loser instead of recording a failed
+evaluation, and scheduling around the lease so the contention does not arise. Backlog §4 tracks the
+scheduling half.
+
+**Still true, and not addressed here:** a candidate that lost a race is recorded as a failed
+evaluation it never received, `_ESTABLISHED_RUN_STATES` includes `FAILED` so a resume never
+re-dispatches it, and the optimizer is still handed that observation as evidence about the parameter
+point. Fixing those is the re-queue option above.
 
 ---
 

--- a/packages/runtime/src/opensdl_runtime/campaign.py
+++ b/packages/runtime/src/opensdl_runtime/campaign.py
@@ -31,6 +31,7 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
+from itertools import groupby
 from typing import Any
 
 from pydantic import Field, computed_field
@@ -475,19 +476,29 @@ class CampaignRunner:
                 await _call(optimizer.observe, observation)
 
             stopped = False
-            for observation in observations:
-                if not observation.succeeded:
-                    consecutive_failures += 1
-                    if consecutive_failures >= max_consecutive_failures:
-                        stop_reason = CampaignStopReason.FAILURE_LIMIT
-                        stop_detail = (
-                            f"{consecutive_failures} consecutive iterations failed, so the failure "
-                            f"is systematic rather than routine; last error: {observation.error}"
-                        )
-                        stopped = True
-                        break
-                    continue
+            # A batch that got something through is a working laboratory, so the candidates that
+            # lost a race for an instrument in that batch say nothing about whether failure is
+            # systematic. Counting each of them separately stopped a campaign whose only problem
+            # was being asked to run more at once than the laboratory owns: four candidates against
+            # one exclusive instrument reached the default limit of three on the first batch and
+            # reported the failure as systematic, having measured one candidate out of eight.
+            # A batch in which nothing succeeded still counts every attempt in it, so a laboratory
+            # that is genuinely failing stops exactly as promptly as before.
+            if observations and not any(item.succeeded for item in observations):
+                consecutive_failures += len(observations)
+                if consecutive_failures >= max_consecutive_failures:
+                    stop_reason = CampaignStopReason.FAILURE_LIMIT
+                    stop_detail = (
+                        f"{consecutive_failures} consecutive iterations failed with nothing "
+                        "completing in between, so the failure is systematic rather than routine; "
+                        f"last error: {observations[-1].error}"
+                    )
+                    stopped = True
+            elif observations:
                 consecutive_failures = 0
+            for observation in [] if stopped else observations:
+                if not observation.succeeded:
+                    continue
                 if _reaches_targets(observation, problem):
                     stop_reason = CampaignStopReason.TARGET_REACHED
                     stop_detail = _target_detail(observation, problem)
@@ -1325,13 +1336,19 @@ def _trailing_failures(history: Sequence[CampaignObservation]) -> int:
 
     The consecutive-failure limit is a statement about the laboratory, not about one process, so a
     restart that reset this count would let an unattended loop fail past the limit it declared.
+
+    Counted per batch, matching the loop: a batch in which anything succeeded ends the run, because
+    a laboratory that completed one candidate is working and the rest lost a race rather than
+    revealing a fault. Counting per observation here would let a resume reach the limit the loop
+    itself would not have.
     """
 
     count = 0
-    for observation in reversed(history):
-        if observation.succeeded:
+    for _, batch in groupby(reversed(history), key=lambda item: item.batch):
+        attempts = list(batch)
+        if any(item.succeeded for item in attempts):
             break
-        count += 1
+        count += len(attempts)
     return count
 
 

--- a/packages/runtime/tests/test_campaign.py
+++ b/packages/runtime/tests/test_campaign.py
@@ -31,6 +31,7 @@ from opensdl_core import (
 from opensdl_policy import PolicyEngine, PolicyRule
 from opensdl_runtime import ReferenceRuntime
 from opensdl_runtime.campaign import (
+    _trailing_failures,
     BatchOptimizer,
     CampaignIterationState,
     CampaignObservation,
@@ -2349,3 +2350,106 @@ async def test_a_campaign_that_found_nothing_records_no_best(tmp_path) -> None:
     )
     assert result.best is None
     assert completed.payload["best"] is None
+
+
+@pytest.mark.asyncio
+async def test_losing_a_race_for_an_instrument_does_not_stop_the_campaign(tmp_path) -> None:
+    """A laboratory that completed a candidate is working, whatever else contended for the bench.
+
+    Every non-succeeding observation used to count toward `max_consecutive_failures`, so a
+    laboratory asked to run more at once than it owns stopped on its first batch and reported the
+    failure as systematic. Four candidates against one exclusive instrument reached the default
+    limit of three immediately, having measured one candidate out of eight, and named a cause an
+    operator would go looking for in the instrument or the chemistry.
+    """
+
+    adapter = ScoreAdapter()
+    runner, repositories = build_campaign(tmp_path, adapter)
+    repositories.upsert_resource(Resource(id="probe-bench", name="Probe bench", type="simulator"))
+
+    result = await runner.run(
+        probe_workflow(
+            capability="test.score_exclusive", outputs={"score": "${steps.score.output.score}"}
+        ),
+        ScriptedOptimizer(
+            [
+                [{"x": 1.0}, {"x": 2.0}, {"x": 3.0}, {"x": 4.0}],
+                [{"x": 5.0}, {"x": 6.0}, {"x": 7.0}, {"x": 8.0}],
+            ]
+        ),
+        environment="simulation",
+        operator_id="operator/alice",
+        max_iterations=8,
+        batch_size=4,
+        max_parallel_runs=4,
+    )
+
+    assert result.stop_reason is CampaignStopReason.MAX_ITERATIONS
+    # Both batches got a candidate through, so both are laboratories that worked.
+    assert len(result.successes) == 2
+    assert all("resources busy" in (item.error or "") for item in result.failures)
+
+
+@pytest.mark.asyncio
+async def test_a_batch_that_completes_nothing_still_stops_the_campaign(tmp_path) -> None:
+    """The stop rule has to keep working, or the fix above has traded one failure for another.
+
+    Nothing succeeding is what "systematic" means. Every attempt in a batch that got nothing
+    through still counts, so a genuinely failing laboratory stops exactly as promptly as it did
+    before — three failed attempts, whether they arrive one batch at a time or all at once.
+    """
+
+    adapter = ScoreAdapter(fail_on={1.0, 2.0, 3.0, 4.0})
+    runner, _ = build_campaign(tmp_path, adapter)
+
+    result = await runner.run(
+        probe_workflow(),
+        ScriptedOptimizer([[{"x": 1.0}, {"x": 2.0}, {"x": 3.0}, {"x": 4.0}]]),
+        environment="simulation",
+        operator_id="operator/alice",
+        max_iterations=8,
+        batch_size=4,
+        max_parallel_runs=4,
+    )
+
+    assert result.stop_reason is CampaignStopReason.FAILURE_LIMIT
+    assert "systematic rather than routine" in result.stop_detail
+    assert result.successes == []
+
+
+def test_the_trailing_failure_count_a_resume_rebuilds_is_read_per_batch(tmp_path) -> None:
+    """A resume must reach the same count the loop itself would have, or it stops early.
+
+    Counting observations rather than batches here would let a restart inherit a limit the running
+    campaign had already reset, and stop a campaign the loop was willing to continue.
+    """
+
+    def observation(iteration: int, batch: int, *, succeeded: bool) -> CampaignObservation:
+        return CampaignObservation(
+            iteration=iteration,
+            candidate={"x": float(iteration)},
+            batch=batch,
+            score=1.0 if succeeded else None,
+            status=(
+                CampaignObservationStatus.SUCCEEDED
+                if succeeded
+                else CampaignObservationStatus.FAILED
+            ),
+            error=None if succeeded else "resources busy: ['bench']",
+        )
+
+    # One batch, one winner and three losers: the laboratory worked, so nothing trails.
+    served = [
+        observation(0, 0, succeeded=True),
+        observation(1, 0, succeeded=False),
+        observation(2, 0, succeeded=False),
+        observation(3, 0, succeeded=False),
+    ]
+    assert _trailing_failures(served) == 0
+
+    # A batch that got nothing through counts every attempt in it.
+    dead = served + [observation(index, 1, succeeded=False) for index in range(4, 8)]
+    assert _trailing_failures(dead) == 4
+
+    # And an earlier working batch still ends the count.
+    assert _trailing_failures(dead + [observation(8, 2, succeeded=True)]) == 0


### PR DESCRIPTION
Resolves the operator-facing half of audit finding A7, reproduced in #15.

## The defect

A campaign's consecutive-failure limit counted every observation that did not succeed. A laboratory declaring more parallelism than it has exclusive instruments produces a loser in every batch, so with defaults (`max_consecutive_failures=3`):

```
stop_reason : failure_limit
stop_detail : 3 consecutive iterations failed, so the failure is systematic rather than routine;
              last error: resources busy: ['probe-bench']
successes   : 1 of 8 candidates
```

The campaign stopped on its first batch. Nothing was wrong with the instrument, the chemistry, or the candidates — the laboratory was asked to run four things at once and can run one. An operator reading "systematic" goes looking in the wrong place, and unattended operation, which is the point of the loop, ends immediately.

After:

```
stop_reason : max_iterations
stop_detail : ran the configured budget of 8 iterations
successes   : 2
```

## The change

"Systematic" now means a batch in which **nothing** completed. A batch that got a candidate through is a working laboratory, so the candidates that lost a race in it no longer count toward the limit.

Deliberately preserved:

- A batch that completed nothing still counts **every attempt in it**, so a genuinely failing laboratory stops exactly as promptly as before — three failed attempts, whether they arrive one batch at a time or all at once.
- `batch_size=1`, the default, is identical to previous behaviour in every case.
- `_trailing_failures` reads the same way, so a resume cannot inherit a limit the running loop had already reset.

Not counting contention at all was rejected: a resource held by something outside the campaign would leave the loop running forever with nothing to show.

## What each check has to see in order to fail

| Test | Mutation | Result |
|---|---|---|
| `...losing_a_race_for_an_instrument_does_not_stop_the_campaign` | count every failed observation (previous behaviour) | fails |
| `...a_batch_that_completes_nothing_still_stops_the_campaign` | count one per dead batch rather than every attempt | fails |
| `...trailing_failure_count_a_resume_rebuilds_is_read_per_batch` | rebuild the resume count per observation | fails |

The second is the regression guard: without it this change could have traded one failure for another by weakening the stop rule.

## What stays open

A7's larger half, recorded in the audit rather than fixed. A candidate that lost a race is still written down as a failed evaluation it never received; `_ESTABLISHED_RUN_STATES` includes `FAILED`, so a resume never re-dispatches it; and the optimizer is handed that observation as evidence about the parameter point. Re-queuing the loser, or scheduling around the lease so contention never arises, is the honest end state — Backlog §4 tracks the scheduling half. A6 also remains open, pending intervention acknowledgement.

`make lint`, `make test` (612 passed), `make docs`, `make example` all pass.
