### PR TITLE
Lead the README with the loop rather than with prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License: Apache-2.0"></a>
 </p>
 
+<p align="center">
+  <img src="examples/discovering-colors/renders/discovering-colors.png" width="880"
+       alt="Left: a 96-well microplate photographed from directly above inside the reference cell, every well a different color. Right: the campaign that produced them, showing the target color, the closest sample so far, and the search space contracting">
+  <br>
+  <sub>A closed loop part-way through: ninety-six dye recipes on one plate, each well carrying the
+  color its own run measured, beside the search that proposed them. Both halves are generated from
+  that run's record rather than drawn by hand.
+  <a href="examples/discovering-colors/README.md">The example</a> ·
+  <a href="docs/guides/closed-loop-campaign.md">how a campaign works</a>.</sub>
+</p>
+
 ## What OpenSDL is
 
 OpenSDL is a framework for declaring what a laboratory can do, executing those declarations as

--- a/WRITING-RULES.md
+++ b/WRITING-RULES.md
@@ -1,0 +1,50 @@
+# Writing conventions
+
+## Register
+
+OpenSDL's prose is written for a working scientist or engineer evaluating whether to build a
+laboratory on this framework, and for the agents that will operate one. It states what the software
+does and what it does not, in specific terms, and it declines to sell. Claims carry the evidence
+that supports them or say plainly that the evidence is missing.
+
+## Audience
+
+- Someone arriving at the repository cold, deciding in a few minutes whether it is real.
+- A laboratory owner deciding what to depend on, who needs the limits stated before the features.
+- An agent operating a laboratory, which needs instructions it can follow without inferring intent.
+
+## Conventions already recorded elsewhere
+
+`AGENTS.md` governs repository structure, architecture rules, and the definition of a complete
+change. `.agents/skills/` holds the recurring procedures. Neither is restated here.
+
+---
+
+## Lead the README with the image
+
+**Rule:** The root README carries one hero image immediately after the title and badges, above the
+first prose section. A reader should not have to scroll to see what the framework produces. Images
+that illustrate a specific section stay in that section; the hero is separate from them and is not
+a duplicate of one.
+**Scope:** `README.md` at the repository root, and the README of any example that ships a rendered
+artifact.
+**Origin:** 2026-08-11 — the repository's only image sat at line 113 of 173, below five sections of
+prose, and had to be scrolled to.
+
+## Show the run, not the machine
+
+**Rule:** When a published image can show the framework doing something, prefer it to a portrait of
+the equipment. A still of a cell says a scene was modelled; a frame of a campaign mid-search says
+the loop closes. State in the caption that the image was generated from a recorded run, when it was.
+**Scope:** Hero and section images in `README.md` and example READMEs.
+**Origin:** 2026-08-11 — the front door led with a static render of the reference cell while a frame
+of an actual campaign existed.
+
+## Size an image for where it is read
+
+**Rule:** Deliver a rendered artifact at the width it is displayed at, not at the largest width it
+can be produced at. An oversized file is resampled by whatever displays it, and that resampling is
+what makes type look soft. Supersample during generation, then resample down to the delivery size.
+**Scope:** Any rendered image committed to the repository or published from it.
+**Origin:** 2026-08-11 — a 3840px frame read as blurry everywhere it was viewed; the same frame
+resampled to 1920px read sharp.

--- a/propagation.yaml
+++ b/propagation.yaml
@@ -55,6 +55,7 @@ nodes:
     paths:
       - "AGENTS.md"
       - "CLAUDE.md"
+      - "WRITING-RULES.md"
       - "**/AGENTS.md"
       - "**/CLAUDE.md"
       - ".agents/**"


### PR DESCRIPTION
The repository's only image sat at line 113 of 173, below five sections of prose. A reader arriving
cold had to scroll past everything to see what the framework produces.

The hero is now directly under the badges, and it is a frame of a campaign mid-search rather than a
portrait of the cell. A still of a machine says a scene was modelled; ninety-six measured colours on
a plate beside the search that proposed them says the loop closes.

The reference-scene still stays where it was, in the digital-twin section it illustrates — its
caption is about the scene, not about a run, so it is not a duplicate of the hero.

Adds `WRITING-RULES.md`, recording the three conventions this settled: lead the README with the
image, show the run rather than the equipment, and size a rendered artifact for the width it is read
at rather than the width it can be produced at.

`make lint` and `make docs` pass. The hero resolves from `raw.githubusercontent.com` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYKGZgEBThR2HbwKU5nyGV