### PR TITLE
Head the README with the cell, and keep the campaign with its example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@
 </p>
 
 <p align="center">
-  <img src="examples/discovering-colors/renders/discovering-colors.png" width="880"
-       alt="Left: a 96-well microplate photographed from directly above inside the reference cell, every well a different color. Right: the campaign that produced them, showing the target color, the closest sample so far, and the search space contracting">
+  <img src="examples/digital-twin-surrogate/scene/assets/preview.png" width="880"
+       alt="An enclosed benchtop cell: an aluminium-extrusion frame over a deck of microplate positions, with a gantry beam carrying the head above it">
   <br>
-  <sub>A closed loop part-way through: ninety-six dye recipes on one plate, each well carrying the
-  color its own run measured, beside the search that proposed them. Both halves are generated from
-  that run's record rather than drawn by hand.
-  <a href="examples/discovering-colors/README.md">The example</a> ·
-  <a href="docs/guides/closed-loop-campaign.md">how a campaign works</a>.</sub>
+  <sub>The repository's one reference scene, rendered from the procedural Blender source committed
+  beside it; the optional viewer draws this same scene when replaying a recorded run. OpenSDL ships
+  no equipment-model catalog — a laboratory authors its own scene in its own repository.
+  <a href="examples/digital-twin-surrogate/scene/renders/opensdl-surrogate-cell.mp4">The 49-second
+  render</a> · <a href="examples/digital-twin-surrogate/README.md">the example behind it</a> ·
+  <a href="docs/guides/build-a-twin-scene.md">building a scene</a>.</sub>
 </p>
 
 ## What OpenSDL is
@@ -88,6 +89,17 @@ gets back to within half a percent of the recipe it was never shown. It also car
 photograph the finished plate inside the reference cell and compose the published frame from the
 campaign's own record.
 
+<p align="center">
+  <img src="examples/discovering-colors/renders/discovering-colors.png" width="880"
+       alt="Left: a 96-well microplate photographed from directly above inside the reference cell, every well a different color. Right: the campaign that produced them, showing the target color, the closest sample so far, and the search space contracting">
+  <br>
+  <sub>That campaign part-way through: ninety-six recipes on one plate, each well carrying the color
+  its own run measured, beside the search that proposed them. Both halves are generated from the
+  run's record rather than drawn by hand.
+  <a href="examples/discovering-colors/README.md">The example</a> ·
+  <a href="docs/guides/closed-loop-campaign.md">how a campaign works</a>.</sub>
+</p>
+
 ## What the alpha provides
 
 - a versioned laboratory manifest, and domain-neutral models for capabilities, resources, workflows,
@@ -119,19 +131,8 @@ The viewer is read-only and draws only what the stored records contain. A scene 
 kinematics, or collision model, so what it shows is evidence about the run that was recorded, not
 about reachability, clearance, transfer accuracy, calibration, or safe placement.
 [Lab-specific digital twins](docs/architecture/digital-twin.md) sets out the ownership model and what
-a projection can and cannot show.
-
-<p align="center">
-  <img src="examples/digital-twin-surrogate/scene/assets/preview.png" width="720"
-       alt="An enclosed benchtop cell: an aluminium-extrusion frame over a deck of microplate positions, with a gantry beam carrying the head above it">
-  <br>
-  <sub>The repository's one reference scene, rendered from the procedural Blender source committed
-  beside it; the optional viewer draws this same scene when replaying a recorded run. OpenSDL ships
-  no equipment-model catalog — a laboratory authors its own scene in its own repository.
-  <a href="examples/digital-twin-surrogate/scene/renders/opensdl-surrogate-cell.mp4">The 49-second
-  render</a> · <a href="examples/digital-twin-surrogate/README.md">the example behind it</a> ·
-  <a href="docs/guides/build-a-twin-scene.md">building a scene</a>.</sub>
-</p>
+a projection can and cannot show. The cell at the top of this page is the reference scene the viewer
+draws; [building a scene](docs/guides/build-a-twin-scene.md) is how a laboratory authors its own.
 
 ## Build a laboratory of your own
 

--- a/WRITING-RULES.md
+++ b/WRITING-RULES.md
@@ -31,14 +31,20 @@ artifact.
 **Origin:** 2026-08-11 — the repository's only image sat at line 113 of 173, below five sections of
 prose, and had to be scrolled to.
 
-## Show the run, not the machine
+## Show the run where the run is the subject
 
-**Rule:** When a published image can show the framework doing something, prefer it to a portrait of
-the equipment. A still of a cell says a scene was modelled; a frame of a campaign mid-search says
-the loop closes. State in the caption that the image was generated from a recorded run, when it was.
+**Rule:** An image of the framework doing something belongs beside the text that describes that
+thing, and should say in its caption that it came from a recorded run. It does not displace the
+header. The root README's header image is the reference cell, because the first thing a reader needs
+is what a laboratory built on this looks like; a campaign frame is evidence for a particular claim
+and sits with that claim.
 **Scope:** Hero and section images in `README.md` and example READMEs.
 **Origin:** 2026-08-11 — the front door led with a static render of the reference cell while a frame
 of an actual campaign existed.
+**Superseded:** 2026-08-11 — the original rule read "show the run, not the machine" and moved the
+campaign frame to the header. Sean reversed it: the cell is the header, and the campaign frame comes
+later as an example. The narrower rule above is what survives — prefer the run *where the run is the
+subject*, rather than everywhere.
 
 ## Size an image for where it is read
 


### PR DESCRIPTION
The header image is now the reference cell — what a laboratory built on this actually looks like.

The campaign frame moves down into the quick start, beside the paragraph describing the example that
produces it. That is the claim it is evidence for, so it reads as evidence rather than as decoration
at the top.

Neither image appears twice. The scene's links (the 49-second render, the example, the scene guide)
travel with the cell to the top, and the digital-twin section keeps a pointer to the scene guide,
which is the one link a reader of that section would go looking for.

`WRITING-RULES.md` carried a rule saying to lead with the run rather than the machine. It was written
earlier today from a single correction and generalized further than that correction supported. It is
narrowed rather than deleted, with the reversal recorded under `Superseded:` — prefer the run where
the run is the subject, not everywhere.

`make lint` and `make docs` both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYKGZgEBThR2HbwKU5nyGV