### PR TITLE
Queue for the bench instead of abandoning the experiment

### DIFF
--- a/apps/controller/src/opensdl_controller/system.py
+++ b/apps/controller/src/opensdl_controller/system.py
@@ -223,6 +223,7 @@ class OpenSDLSystem:
             max_concurrency=manifest.spec.runtime.max_concurrency,
             default_timeout_seconds=manifest.spec.runtime.default_timeout_seconds,
             lease_ttl_seconds=manifest.spec.runtime.lease_ttl_seconds,
+            lease_wait_seconds=manifest.spec.runtime.lease_wait_seconds,
             default_run_context=(
                 {"twinBinding": twin_binding} if twin_binding is not None else None
             ),

--- a/docs/development/backlog.md
+++ b/docs/development/backlog.md
@@ -172,10 +172,11 @@ Check an item only when its stated evidence exists in the repository or a linked
 
 - [ ] Deploy one shared simulator controller with persistent PostgreSQL storage.
 - [ ] Add authentication, scoped service identities, and server-derived actor attribution.
-- [ ] Add trustworthy multi-user leases and run ownership. Starting a run is now one conditional
-  write, so two callers cannot both claim it and a concurrent-submission test covers that; resource
-  leasing is still a check-then-act — `acquire_leases` reads every lease and then writes them in two
-  passes — and no PostgreSQL service exercises either.
+- [ ] Add trustworthy multi-user leases and run ownership. Starting a run is one conditional write,
+  so two callers cannot both claim it, and a concurrent-submission test covers that. Resource
+  leasing is also settled by the database now: `acquire_leases` claims each resource with a write
+  whose own `WHERE` decides the outcome, in sorted order, all-or-nothing. What remains is that no
+  PostgreSQL service exercises either path.
 - [ ] Add pluggable policy providers and signed policy revision evidence.
 - [ ] Add PostgreSQL CI, migrations across released versions, backup, restore, and disaster tests.
 - [ ] Add OpenTelemetry traces and metrics tied to run, task, adapter, and deployment identity.

--- a/docs/guides/closed-loop-campaign.md
+++ b/docs/guides/closed-loop-campaign.md
@@ -76,8 +76,22 @@ costs a dependency on the declarations and protocols, not on storage, policy and
 recovering a recipe from its color alone. That example also carries the scripts that turn a
 recorded round into a rendered plate and a composed frame.
 
-## What is still open
+## Running more than one candidate at a time
 
-The runner does not schedule around resource leases, so two candidates needing the same exclusive
-instrument are dispatched together and one fails as busy. That is why parallelism defaults to one,
-and why raising it means knowing the laboratory can carry it.
+`max_parallel_runs` is how many candidates execute together. Raising it above one used to throw
+work away: two candidates needing the same exclusive instrument were dispatched together and the
+loser failed on the lease, having already become a run.
+
+A task now queues for equipment somebody else holds, and runs when it is released. `run` bounds the
+queue with `lease_wait_seconds` from the manifest's `runtime` block, which defaults to two minutes;
+when it runs out the task fails as busy exactly as it did before. Set it to zero for a laboratory
+that should refuse rather than wait.
+
+Waiting is safe because a task holds its resources only for its own duration and releases them in a
+`finally`. Nothing holds one instrument while queuing for another, so the queue cannot deadlock.
+`acquire_leases` remains the authority on who holds what: it claims a set all-or-nothing, in sorted
+order, with each claim decided by the database rather than by the process asking.
+
+The wait is on the record. A task that queues emits `TaskWaitingForResources` and, when it gets the
+bench, `TaskResourcesAcquired`, so contention reads as contention instead of as an unexplained gap
+between timestamps.

--- a/packages/runtime/src/opensdl_runtime/engine.py
+++ b/packages/runtime/src/opensdl_runtime/engine.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import random
+import time
 from copy import deepcopy
 from typing import Any
 
@@ -30,6 +32,12 @@ from opensdl_core import (
 from opensdl_policy import PolicyEvaluator
 from opensdl_storage import ArtifactStore, RepositoryStore
 from opensdl_workflows import resolve_mapping, topological_layers, validate_workflow_graph
+
+#: How long a task waits before asking again for equipment somebody else holds, and the ceiling
+#: that backoff climbs to. Short enough that a freed instrument is picked up promptly, long enough
+#: that a queue of tasks is not a busy loop against the store.
+_LEASE_POLL_SECONDS = 0.05
+_LEASE_POLL_CEILING = 2.0
 
 #: Task states a resumed run must never dispatch again. Either the task is active or was active
 #: (`RUNNING`, `RETRYING`), or the record already says the physical outcome is unknown
@@ -99,6 +107,7 @@ class ReferenceRuntime:
         max_concurrency: int = 4,
         default_timeout_seconds: float = 60.0,
         lease_ttl_seconds: float = 300.0,
+        lease_wait_seconds: float = 120.0,
         default_run_context: dict[str, Any] | None = None,
     ) -> None:
         self.registry = registry
@@ -108,6 +117,7 @@ class ReferenceRuntime:
         self.max_concurrency = max_concurrency
         self.default_timeout_seconds = default_timeout_seconds
         self.lease_ttl_seconds = lease_ttl_seconds
+        self.lease_wait_seconds = lease_wait_seconds
         self.default_run_context = deepcopy(default_run_context or {})
         self._semaphore = asyncio.Semaphore(max_concurrency)
 
@@ -341,6 +351,62 @@ class ReferenceRuntime:
             )
         return replaced
 
+    async def _hold_resources(
+        self,
+        resources: list[str],
+        *,
+        task: TaskRecord,
+        run: RunRecord,
+        seconds: float,
+        campaign_id: str | None,
+    ) -> bool:
+        """Take every resource this task needs, waiting for whoever holds them.
+
+        A laboratory queues for equipment. Failing the moment another task holds the balance is
+        what made `max_parallel_runs` above one produce one success and a row of busy failures:
+        the candidates were dispatched together, and the ones that lost the race were already runs
+        by the time they lost it.
+
+        Waiting is safe here for a reason worth stating, because it would not be safe in general.
+        A task holds its resources only for its own duration and releases them in a `finally`, so
+        no task ever holds one resource while waiting for another. Without that, this loop would
+        be a deadlock. `acquire_leases` is also all-or-nothing and claims in sorted order, so two
+        tasks wanting overlapping sets contend over the same resource first and neither walks away
+        holding half of what the other needs.
+
+        The wait is bounded. When it runs out the caller fails exactly as it did before, because a
+        task that queues forever is worse than one that says the bench is busy.
+        """
+        first = self.repositories.acquire_leases(resources, task.id, seconds)
+        if first or self.lease_wait_seconds <= 0:
+            return first
+
+        # Say that the task is waiting rather than let a gap in the timestamps imply it.
+        self._emit(
+            "TaskWaitingForResources",
+            run=run,
+            task=task,
+            payload={"resources": sorted(resources), "waitSeconds": self.lease_wait_seconds},
+            campaign_id=campaign_id,
+        )
+        deadline = time.monotonic() + self.lease_wait_seconds
+        delay = _LEASE_POLL_SECONDS
+        while time.monotonic() < deadline:
+            # Jittered so that several tasks released together do not retry in lockstep and hand
+            # the resource to the same one every round.
+            await asyncio.sleep(min(delay, max(0.0, deadline - time.monotonic())))
+            if self.repositories.acquire_leases(resources, task.id, seconds):
+                self._emit(
+                    "TaskResourcesAcquired",
+                    run=run,
+                    task=task,
+                    payload={"resources": sorted(resources)},
+                    campaign_id=campaign_id,
+                )
+                return True
+            delay = min(delay * 2, _LEASE_POLL_CEILING) * (0.5 + random.random())
+        return False
+
     def _lease_seconds_for(self, timeout: float, max_retries: int) -> float:
         """How long this task's resource lease has to last.
 
@@ -545,8 +611,12 @@ class ReferenceRuntime:
             timeout = (
                 step.timeout_seconds or definition.timeout_seconds or self.default_timeout_seconds
             )
-            if not self.repositories.acquire_leases(
-                resources, task.id, self._lease_seconds_for(timeout, max_retries)
+            if not await self._hold_resources(
+                resources,
+                task=task,
+                run=run,
+                seconds=self._lease_seconds_for(timeout, max_retries),
+                campaign_id=campaign_id,
             ):
                 task.state = TaskState.FAILED
                 task.error = f"resources busy: {resources}"

--- a/packages/runtime/tests/test_campaign.py
+++ b/packages/runtime/tests/test_campaign.py
@@ -232,6 +232,7 @@ def build_campaign(
     *,
     policy: PolicyEngine | None = None,
     repositories: Repositories | None = None,
+    lease_wait_seconds: float = 120.0,
 ) -> tuple[CampaignRunner, Repositories]:
     if repositories is None:
         database = Database("sqlite:///:memory:")
@@ -244,6 +245,7 @@ def build_campaign(
         repositories,
         policy or PolicyEngine(default_effect="allow"),
         LocalArtifactStore(tmp_path, repositories),
+        lease_wait_seconds=lease_wait_seconds,
     )
     return CampaignRunner(runtime, repositories), repositories
 
@@ -905,14 +907,14 @@ async def test_a_declared_parallelism_runs_the_batch_concurrently(tmp_path) -> N
 
 
 @pytest.mark.asyncio
-async def test_parallel_candidates_contending_for_one_instrument_are_recorded_as_failures(
+async def test_parallel_candidates_contending_for_one_instrument_both_complete(
     tmp_path,
 ) -> None:
-    """The honest limit of parallel execution: the runner does not schedule around a lease.
+    """Two candidates, one exclusive instrument, and both experiments get measured.
 
-    Two candidates needing the same exclusive instrument are dispatched together, and the loser
-    fails on the lease. It is recorded as an attempted iteration, because a lease failure is a
-    laboratory fact and not a framework error.
+    Dispatching them together used to mean the loser failed on the lease, which is why
+    `max_parallel_runs` defaulted to one: asking a laboratory to run more at once than it owns
+    threw away the surplus. The loser now queues for the bench and runs when it is free.
     """
 
     adapter = ScoreAdapter()
@@ -931,8 +933,12 @@ async def test_parallel_candidates_contending_for_one_instrument_are_recorded_as
         max_parallel_runs=2,
     )
 
-    assert len(result.failures) == 1
-    assert "resources busy" in (result.failures[0].error or "")
+    assert not result.failures
+    assert len(result.successes) == 2
+    assert sorted(item.score for item in result.successes if item.score is not None) == [
+        2.0,
+        3.0,
+    ]
 
 
 # --- 2. Multi-objective and constraints -------------------------------------
@@ -2400,14 +2406,15 @@ async def test_a_campaign_that_found_nothing_records_no_best(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_losing_a_race_for_an_instrument_does_not_stop_the_campaign(tmp_path) -> None:
-    """A laboratory that completed a candidate is working, whatever else contended for the bench.
+async def test_more_candidates_at_once_than_the_laboratory_owns_still_measures_all_of_them(
+    tmp_path,
+) -> None:
+    """Four candidates at a time against one exclusive instrument, and none of them is wasted.
 
-    Every non-succeeding observation used to count toward `max_consecutive_failures`, so a
-    laboratory asked to run more at once than it owns stopped on its first batch and reported the
-    failure as systematic. Four candidates against one exclusive instrument reached the default
-    limit of three immediately, having measured one candidate out of eight, and named a cause an
-    operator would go looking for in the instrument or the chemistry.
+    This measured one candidate out of eight and stopped, calling the result systematic failure:
+    every non-succeeding observation counted toward `max_consecutive_failures`, and three lease
+    losses in the first batch reached the limit. The lease losses came first, so they are what is
+    fixed here; the rule that a busy bench is not a failing science is covered below.
     """
 
     adapter = ScoreAdapter()
@@ -2432,9 +2439,9 @@ async def test_losing_a_race_for_an_instrument_does_not_stop_the_campaign(tmp_pa
     )
 
     assert result.stop_reason is CampaignStopReason.MAX_ITERATIONS
-    # Both batches got a candidate through, so both are laboratories that worked.
-    assert len(result.successes) == 2
-    assert all("resources busy" in (item.error or "") for item in result.failures)
+    # Every candidate queued for the one bench and every candidate was measured.
+    assert not result.failures
+    assert len(result.successes) == 8
 
 
 @pytest.mark.asyncio
@@ -2500,3 +2507,40 @@ def test_the_trailing_failure_count_a_resume_rebuilds_is_read_per_batch(tmp_path
 
     # And an earlier working batch still ends the count.
     assert _trailing_failures(dead + [observation(8, 2, succeeded=True)]) == 0
+
+
+@pytest.mark.asyncio
+async def test_a_busy_bench_is_still_not_a_failing_science(tmp_path) -> None:
+    """The rule from before the wait existed, kept where it can still be reached.
+
+    Queuing removes lease losses from the ordinary path, so the scenario that first exposed this
+    no longer produces one. It can still happen: a wait that runs out, or a laboratory configured
+    to refuse rather than queue. When it does, a lease loss must not count toward
+    `max_consecutive_failures`, because a campaign that measured a candidate is a campaign whose
+    science is working, and stopping would send an operator looking at the chemistry.
+    """
+
+    adapter = ScoreAdapter()
+    runner, repositories = build_campaign(tmp_path, adapter, lease_wait_seconds=0)
+    repositories.upsert_resource(Resource(id="probe-bench", name="Probe bench", type="simulator"))
+
+    result = await runner.run(
+        probe_workflow(
+            capability="test.score_exclusive", outputs={"score": "${steps.score.output.score}"}
+        ),
+        ScriptedOptimizer(
+            [
+                [{"x": 1.0}, {"x": 2.0}, {"x": 3.0}, {"x": 4.0}],
+                [{"x": 5.0}, {"x": 6.0}, {"x": 7.0}, {"x": 8.0}],
+            ]
+        ),
+        environment="simulation",
+        operator_id="operator/alice",
+        max_iterations=8,
+        batch_size=4,
+        max_parallel_runs=4,
+    )
+
+    assert result.stop_reason is CampaignStopReason.MAX_ITERATIONS
+    assert result.successes
+    assert all("resources busy" in (item.error or "") for item in result.failures)

--- a/packages/runtime/tests/test_runtime.py
+++ b/packages/runtime/tests/test_runtime.py
@@ -197,6 +197,7 @@ def build_probe_runtime(
     adapter: ProbeAdapter,
     *,
     policy_effect: Literal["allow", "deny"] = "allow",
+    lease_wait_seconds: float = 120.0,
 ):
     database = Database("sqlite:///:memory:")
     database.initialize()
@@ -211,6 +212,7 @@ def build_probe_runtime(
         repositories,
         PolicyEngine(default_effect=policy_effect),
         LocalArtifactStore(tmp_path, repositories),
+        lease_wait_seconds=lease_wait_seconds,
     )
     return runtime, repositories
 
@@ -996,8 +998,15 @@ async def test_unregistered_resource_stops_the_task_before_dispatch(tmp_path) ->
 
 @pytest.mark.asyncio
 async def test_held_lease_fails_the_task_and_leaves_the_holder_in_place(tmp_path) -> None:
+    """The fail-fast configuration: `lease_wait_seconds=0` refuses rather than queues.
+
+    A caller that wants to know immediately that the bench is busy sets the wait to zero, and then
+    everything below holds: the adapter is never called, the task carries the reason, and the
+    holder's lease is untouched by the attempt.
+    """
+
     adapter = ProbeAdapter()
-    runtime, repositories = build_probe_runtime(tmp_path, adapter)
+    runtime, repositories = build_probe_runtime(tmp_path, adapter, lease_wait_seconds=0)
     assert repositories.acquire_leases(["probe-resource"], "other-task", 60)
     expected = "resources busy: ['probe-resource']"
 
@@ -1690,3 +1699,51 @@ def test_the_lease_covers_every_attempt_the_retry_loop_may_make(tmp_path) -> Non
     assert runtime._lease_seconds_for(timeout=10.0, max_retries=3) >= 40.0
     # The backoff between attempts is inside the lease too, so the bound exceeds the work alone.
     assert runtime._lease_seconds_for(timeout=10.0, max_retries=3) > 40.0
+
+
+@pytest.mark.asyncio
+async def test_a_task_waits_for_an_instrument_and_runs_when_it_is_released(tmp_path) -> None:
+    """The behaviour the wait exists for: queue for the bench instead of abandoning the work."""
+
+    adapter = ProbeAdapter()
+    runtime, repositories = build_probe_runtime(tmp_path, adapter, lease_wait_seconds=10)
+    assert repositories.acquire_leases(["probe-resource"], "other-task", 60)
+
+    async def release_shortly() -> None:
+        await asyncio.sleep(0.2)
+        repositories.release_leases("other-task")
+
+    releaser = asyncio.create_task(release_shortly())
+    await runtime.execute_capability("test.probe", {})
+    await releaser
+
+    assert adapter.calls == 1
+    run = repositories.list_runs()[0]
+    task = repositories.list_tasks(run.id)[0]
+    assert run.state == RunState.COMPLETED
+    assert task.state == TaskState.SUCCEEDED
+    events = [event.type for event in repositories.list_events(run_id=run.id, limit=None)]
+    # The wait is on the record. A gap in the timestamps would leave an operator guessing.
+    assert "TaskWaitingForResources" in events
+    assert "TaskResourcesAcquired" in events
+    assert events.index("TaskWaitingForResources") < events.index("TaskStarted")
+
+
+@pytest.mark.asyncio
+async def test_the_wait_is_bounded_and_fails_the_way_it_always_did(tmp_path) -> None:
+    """A task that queues forever is worse than one that says the bench is busy."""
+
+    adapter = ProbeAdapter()
+    runtime, repositories = build_probe_runtime(tmp_path, adapter, lease_wait_seconds=0.3)
+    # Held well past the wait, so the wait is what ends this rather than the lease expiring.
+    assert repositories.acquire_leases(["probe-resource"], "other-task", 600)
+
+    with pytest.raises(ResourceBusyError) as raised:
+        await runtime.execute_capability("test.probe", {})
+
+    assert adapter.calls == 0
+    assert str(raised.value) == "resources busy: ['probe-resource']"
+    run = repositories.list_runs()[0]
+    assert run.state == RunState.FAILED
+    # The holder is undisturbed by having been waited on.
+    assert not repositories.acquire_leases(["probe-resource"], "third-task", 60)

--- a/packages/schemas/jsonschema/lab-manifest.schema.json
+++ b/packages/schemas/jsonschema/lab-manifest.schema.json
@@ -393,6 +393,12 @@
           "exclusiveMinimum": 0,
           "title": "Lease Ttl Seconds",
           "type": "number"
+        },
+        "lease_wait_seconds": {
+          "default": 120.0,
+          "minimum": 0,
+          "title": "Lease Wait Seconds",
+          "type": "number"
         }
       },
       "title": "RuntimeConfig",

--- a/packages/schemas/src/opensdl_schemas/manifest.py
+++ b/packages/schemas/src/opensdl_schemas/manifest.py
@@ -36,6 +36,11 @@ class RuntimeConfig(OpenSDLModel):
     max_concurrency: int = Field(default=4, gt=0)
     default_timeout_seconds: float = Field(default=60.0, gt=0)
     lease_ttl_seconds: float = Field(default=300.0, gt=0)
+    #: How long a task waits for an instrument another task is holding before it gives up. A
+    #: laboratory queues for equipment; it does not abandon an experiment because a colleague
+    #: reached the balance first. Zero restores the older behaviour of failing on first contention,
+    #: which is what a caller wanting to know immediately that the bench is busy should set.
+    lease_wait_seconds: float = Field(default=120.0, ge=0)
 
 
 class AdapterConfig(OpenSDLModel):


### PR DESCRIPTION
Closes #21.

`max_parallel_runs` above one threw work away. Two candidates needing the same exclusive instrument were dispatched together and the loser failed on the lease — having already become a run, a policy decision, and a durable record. That is why the default was one, and why the campaign guide closed by saying the runner does not schedule around a lease.

## What changed

A task waits for equipment another task holds, bounded by `lease_wait_seconds` in the manifest's `runtime` block, defaulting to two minutes. When the wait runs out it fails as busy exactly as before. A laboratory that should refuse rather than queue sets it to zero and keeps the old behaviour exactly.

## Why waiting is safe here

It would not be safe in general, so the code says why it is safe here. A task holds its resources only for its own duration and releases them in a `finally`, so nothing ever holds one instrument while queuing for another. Without that, this loop would be a deadlock rather than a queue.

`acquire_leases` stays the authority on who holds what: all-or-nothing over a set, claimed in sorted order so overlapping callers contend over the same resource first, with each claim decided by a write whose own `WHERE` settles it.

## Not what the issue proposed

The issue described run-level admission control — resolve each candidate's resource set and admit only disjoint ones. That turned out to be the wrong design. Every candidate in a campaign runs the *same* workflow, so their resource sets are identical and admission control would serialise the whole campaign. Waiting at the point of acquisition keeps steps pipelining: one candidate can be on the reader while another is on the mixer.

## Tests

- Eight candidates over one exclusive bench used to measure one and stop, reporting systematic failure. All eight are measured now.
- Two candidates over one bench both complete.
- A task queues and runs when the holder releases, with the wait ordered before `TaskStarted` in the event stream.
- The wait is bounded, and exhausting it fails with the original message and leaves the holder undisturbed.
- The fail-fast path keeps its original test at `lease_wait_seconds=0` — the adapter is never called, the task carries the reason, the holder's lease is untouched.
- A lease loss still does not count toward `max_consecutive_failures`. That rule came from #16 and the ordinary path no longer produces the case, so it keeps its own test at zero wait rather than silently losing coverage.

## Also

Contention is recorded rather than inferred: `TaskWaitingForResources` when a task queues, `TaskResourcesAcquired` when it gets the bench.

Backlog section 8 described `acquire_leases` as "a check-then-act — reads every lease and then writes them in two passes". That stopped being true in #14. Corrected.

`make lint`, `make test` (650), `make docs`, `make example`, `make viewer` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYKGZgEBThR2HbwKU5nyGV