### PR TITLE
Block the way an instrument blocks, by waiting rather than by spinning

### DIFF
--- a/packages/runtime/tests/test_runtime.py
+++ b/packages/runtime/tests/test_runtime.py
@@ -142,9 +142,14 @@ class BlockingAdapter(CapabilityAdapter):
     async def execute(self, request: ExecutionRequest) -> ExecutionResult:
         self.calls += 1
         self.entered.set()
-        deadline = time.monotonic() + self.seconds
-        while time.monotonic() < deadline:  # pure synchronous computation, no await point
-            pass
+        # Blocks the way a vendor SDK blocks: waiting on something, holding no processor. This was
+        # a `while time.monotonic() < deadline: pass` busy-wait, which occupies a whole core for
+        # the duration. That is fine on a workstation with twenty-four of them and not fine on a
+        # two-vCPU runner already running pytest and SQLAlchemy, where the concurrent run cannot
+        # get the processor it needs: it finished at 1.95s of a 2.03s block, which is
+        # indistinguishable from the stall this test exists to catch. A wait consumes nothing, so
+        # the measurement is of the runtime rather than of how busy the machine is.
+        time.sleep(self.seconds)
         self.finished.set()
         return ExecutionResult(request_id=request.request_id, output={"ok": True})
 
@@ -1306,6 +1311,11 @@ async def test_a_blocking_adapter_does_not_stall_a_concurrent_run(tmp_path) -> N
     That made `max_concurrency` a fiction and stalled every other run's timeout and lease handling
     behind whichever adapter blocked first. The blocking capability here declares a timeout it
     never reaches, so this measures the stall rather than the timeout.
+
+    What is measured is isolation from an adapter that *waits* — a network read, a serial
+    exchange, a vendor SDK call — which is what adapters overwhelmingly do. An adapter that
+    saturates a processor is a different situation with a different answer, and one this test
+    cannot distinguish from a stall on a machine that has no processor to spare.
     """
 
     blocking = BlockingAdapter(seconds=2.0, timeout_seconds=30.0)


### PR DESCRIPTION
Main is red on `test_a_blocking_adapter_does_not_stall_a_concurrent_run`. This fixes it.

## What was wrong

The blocking adapter held a core with `while time.monotonic() < deadline: pass` for two seconds.

On a workstation with twenty-four cores that costs nothing and the concurrent run finishes in 0.1s. On a two-vCPU runner already running pytest and SQLAlchemy there is no processor to spare, and the concurrent run finished at **1.95s of a 2.03s block** — indistinguishable from the stall the test exists to catch.

So the test was measuring how busy the machine is, alongside what it meant to measure.

## What changed

An adapter blocks by *waiting*: a network read, a serial exchange, a vendor SDK call. That is what the runtime's fix is for, and what adapters overwhelmingly do. A wait consumes no processor, so what gets measured is the runtime.

The original defect is still caught. Adapter code running on the calling loop would hold it for the full two seconds, and the concurrent run would finish alongside the blocking one.

## Verification

- Pinned to two cores with `taskset -c 0,1`, three runs, and to a single core.
- The whole suite (661 tests) under `taskset -c 0,1`.
- Both 3.12 and 3.13.

## A correction I made to myself

I first attributed this to the GIL and wrote that into the comment. A synthetic reproduction under the same core restriction did not show it — a busy thread alongside an asyncio task let the task through in 0.06s. The comment now says what was actually demonstrated, which is processor contention on a machine with none to spare, rather than an explanation that sounded right.

## How this happened

I tightened this assertion in #25 to fix an earlier failure of the same test, and merged when CI went green on that branch. The stricter assertion then failed on main. That was avoidable: a test I changed because it was environment-sensitive deserved more than one green run before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYKGZgEBThR2HbwKU5nyGV