### PR TITLE
Re-derive the campaign the README picture claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,27 @@ jobs:
       - run: uv run --locked python scripts/check-boundaries.py
       - run: uv run --locked python scripts/generate-schemas.py --check
 
+  # The campaign behind the README frame, re-derived. `plates.json` is what the picture is rendered
+  # from, so it is a published claim about what this code does, and nothing re-ran it until now: a
+  # change to the optimizer, the dye model, or the instrument noise would have left the frame
+  # describing a campaign the code no longer runs, with every other check still green.
+  #
+  # Its own job rather than a step in `test`, because it costs a minute and would otherwise add
+  # that minute to all three Python versions. Run in parallel it costs nothing on the wall clock.
+  showcase:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.32"
+          python-version: "3.12"
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv sync --locked --all-packages --group dev
+      - run: uv run --locked pytest examples/discovering-colors/tests
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,14 +25,17 @@ OpenSDL is a modular framework for computational and autonomous laboratories.
 - format: `make format` — applies Ruff formatting and safe fixes; `make lint` enforces it
 - schemas: `uv run --locked python scripts/generate-schemas.py`
 
-`make test`, `make lint`, `make viewer`, `make docs`, and `make example` together cover every check
-the pull-request CI job enforces. `make scene` covers the one that runs separately: the headless
+`make test`, `make lint`, `make viewer`, `make docs`, `make example`, and `make showcase` together
+cover every check the pull-request CI job enforces. `make showcase` re-derives the campaign the
+README frame is rendered from, which takes about a minute and is why CI runs it as its own job.
+`make scene` covers the one that runs separately: the headless
 Blender rebuild proving the committed scene is reproducible from source. It needs the exact Blender
 version recorded in the scene's node inventory and takes several minutes. A bare
 `uv run --locked pytest` is not the full suite: `testpaths` excludes `examples/`, so the surrogate
-tests are reachable only through `make test` or `make surrogate`. Narrower targets
-(`unit`, `integration`, `e2e`, `conformance`, `typecheck`, `boundaries`, `validate`, `surrogate`,
-`propagation`, `scene`) and the raw command behind each target are in the `Makefile`.
+tests are reachable only through `make test` or `make surrogate`, and the showcase campaign only
+through `make showcase`. Narrower targets (`unit`, `integration`, `e2e`, `conformance`,
+`typecheck`, `boundaries`, `validate`, `showcase`, `surrogate`, `propagation`, `scene`) and the raw
+command behind each target are in the `Makefile`.
 
 ## Architecture rules
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: sync test unit integration e2e conformance lint format typecheck boundaries propagation schemas validate example surrogate scene viewer docs api clean
+.PHONY: sync test unit integration e2e conformance lint format typecheck boundaries propagation schemas validate example showcase surrogate scene viewer docs api clean
 
 sync:
 	uv sync --locked --all-packages --group dev
@@ -53,6 +53,9 @@ validate:
 
 example:
 	uv run --locked python examples/simulated-color-mixing/run_campaign.py
+
+showcase:
+	uv run --locked pytest examples/discovering-colors/tests
 
 surrogate:
 	uv run --locked --with-editable ./examples/digital-twin-surrogate/adapter pytest examples/digital-twin-surrogate/tests

--- a/examples/discovering-colors/tests/test_showcase_reproducibility.py
+++ b/examples/discovering-colors/tests/test_showcase_reproducibility.py
@@ -1,0 +1,101 @@
+"""The committed showcase must still be what the code produces.
+
+`plates.json` is the campaign behind the frame in the README: every well of every round, what went
+into it, and what the colorimeter read. The frame is rendered from that file, so the file is the
+claim, and nothing until now re-derived it. A change to the optimizer, the dye model, or the
+instrument's noise would have left a published picture describing a campaign the code no longer
+runs, and every test would still have passed — the campaign is an example, and examples are not on
+the default test path.
+
+The comparison ignores identifiers and keeps everything else. A campaign mints a fresh
+`campaign_id` and a fresh `run_id` per well on every execution, so byte equality is not available
+and demanding it would make this fail for the one reason that means nothing. What must not move is
+the science: the recipes tried, the colours measured, the errors, and where the search ended up.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+EXAMPLE = Path(__file__).resolve().parents[1]
+COMMITTED = EXAMPLE / "plates.json"
+
+#: Minted fresh on every run and carrying no scientific content.
+VOLATILE = frozenset({"campaign_id", "run_id"})
+
+
+def _stable(node: Any) -> Any:
+    """The document with its identifiers removed, at any depth."""
+
+    if isinstance(node, dict):
+        return {key: _stable(value) for key, value in node.items() if key not in VOLATILE}
+    if isinstance(node, list):
+        return [_stable(value) for value in node]
+    return node
+
+
+def _first_difference(committed: Any, regenerated: Any, path: str = "") -> str | None:
+    """Where the two documents first disagree, in enough detail to act on.
+
+    A bare "the campaign changed" would send somebody diffing a six-hundred-well JSON file by eye.
+    """
+    if isinstance(committed, dict) and isinstance(regenerated, dict):
+        for key in sorted(set(committed) | set(regenerated)):
+            if key not in committed:
+                return f"{path}.{key}: only in the regenerated campaign"
+            if key not in regenerated:
+                return f"{path}.{key}: only in the committed campaign"
+            found = _first_difference(committed[key], regenerated[key], f"{path}.{key}")
+            if found:
+                return found
+        return None
+    if isinstance(committed, list) and isinstance(regenerated, list):
+        if len(committed) != len(regenerated):
+            return f"{path}: {len(committed)} entries committed, {len(regenerated)} regenerated"
+        for index, (left, right) in enumerate(zip(committed, regenerated, strict=True)):
+            found = _first_difference(left, right, f"{path}[{index}]")
+            if found:
+                return found
+        return None
+    if committed != regenerated:
+        return f"{path}: committed {committed!r}, regenerated {regenerated!r}"
+    return None
+
+
+@pytest.mark.e2e
+def test_the_committed_campaign_is_what_the_code_still_produces(tmp_path: Path) -> None:
+    """Re-run the published campaign and compare it with the file the frame was rendered from."""
+
+    laboratory = tmp_path / "discovering-colors"
+    # The renders are the output and the store is the previous run's evidence; neither is an input.
+    shutil.copytree(
+        EXAMPLE,
+        laboratory,
+        ignore=shutil.ignore_patterns(".opensdl", "__pycache__", "renders", "tests"),
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "run_campaign.py"],
+        cwd=laboratory,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr[-4000:]
+
+    regenerated = json.loads((laboratory / "plates.json").read_text(encoding="utf-8"))
+    committed = json.loads(COMMITTED.read_text(encoding="utf-8"))
+
+    difference = _first_difference(_stable(committed), _stable(regenerated))
+    assert difference is None, (
+        f"the committed campaign no longer matches what the code produces at {difference}. "
+        "The README frame is rendered from this file, so regenerate it and the frame together: "
+        "`uv run --locked python examples/discovering-colors/run_campaign.py`"
+    )


### PR DESCRIPTION
`plates.json` is what the showcase frame in the README is rendered from — every well of every round, what went into it, and what the colorimeter read. It is a published claim about what this code does, and **nothing re-ran it.**

A change to the optimizer, the dye model, or the instrument's noise would have left a picture in the README describing a campaign the code no longer runs, with every other check still green. Examples are not on the default test path, so nothing was watching.

## Why not a byte diff

A campaign mints a fresh `campaign_id` and a fresh `run_id` per well on every execution, so the file differs on every run for the one reason that carries no meaning. Demanding byte equality would make this fail constantly and get deleted.

Identifiers are stripped at any depth; everything else is compared — the recipes tried, the colours measured, the errors, where the search ended up.

## Verified failing, not just passing

Changing the simulator seed produces:

```
.best.measured_rgb[0]: committed 72.31714298414094, regenerated 71.68308612059515
```

That precision is the point. A bare "the campaign changed" would send somebody diffing a six-hundred-well JSON document by eye.

Good news from writing it: the committed showcase **is** currently honest. It reproduces exactly.

## Its own CI job

It costs a minute, and as a step in `test` it would add that minute to all three Python versions. In parallel it costs nothing on the wall clock. Same reasoning the scene rebuild uses, one tier cheaper.

`make showcase` locally; documented in `AGENTS.md` alongside the other gates.

## Gates

`make lint` 0 · `make test` **707 passed** · `make showcase` passes in 59s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PcmK6wy24Fokk5hqtfH74