### PR TITLE
Write down the decisions before they are lost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,10 @@ command behind each target are in the `Makefile`.
 - Public models are typed and exported as versioned schemas.
 - Database access goes through repository interfaces.
 - A change is complete when code, tests, schemas, examples, and documentation agree.
+- A laboratory with one instrument stays expressible in about fifteen manifest lines, runnable in
+  one process against SQLite, with no scheduler, broker, or optional service. Facility features are
+  opt-in by configuration, never by requirement, and a change that lengthens the minimum manifest
+  needs justifying. `tests/test_minimal_laboratory.py` enforces this.
 
 Use the nearest nested `AGENTS.md` when working inside a specialized subsystem.
 
@@ -62,3 +66,6 @@ Use the nearest nested `AGENTS.md` when working inside a specialized subsystem.
   OpenSDL manifests, policy, and runtime contracts control laboratory actions.
 - Repository skills live in `.agents/skills/`. Use them for recurring procedures and keep durable
   rules in `AGENTS.md`.
+- `docs/development/buildout.md` is the canonical plan for facility-scale work: the decisions taken,
+  why, how each is enforced, and what remains open. Read it before facility work and update it when
+  a decision changes.

--- a/docs/development/buildout.md
+++ b/docs/development/buildout.md
@@ -1,0 +1,229 @@
+# Facility buildout
+
+The canonical plan for the facility-scale program: what has been decided, why, how each decision is
+kept from decaying, and what remains open.
+
+## What belongs here
+
+This page is the one to read before doing facility work, and the one to update when a decision
+changes. It holds **decisions and their reasoning**, which nothing else in the repository does.
+
+- [The roadmap](roadmap.md) tracks releases. It says what ships.
+- [The backlog](backlog.md) tracks framework work items. It says what remains.
+- This page tracks the program. It says **what was decided and why**, so a decision survives the
+  conversation that produced it.
+
+The distinction matters because of a demonstrated failure here. The
+[2026-08-05 audit](audit-2026-08-05.md) is 945 lines of correct analysis whose own header records
+that nothing in it has been acted on. A document disconnected from work decays into archaeology.
+Every decision below therefore names the mechanism that enforces it, and a decision enforced only
+by intention is marked as such, because that is the honest description of its durability.
+
+## Decision log
+
+Each entry carries a status and the thing that would catch its violation. `Enforced by: intent`
+means nothing would catch it, which is a standing invitation to find a better mechanism.
+
+### D1 — Facility scale, not another cell
+
+**Decided.** The next showcase is a laboratory facility, not a larger single cell.
+
+A single cell has already been demonstrated and a second one proves nothing new. The interesting
+claim is not more throughput; it is that a facility is a *different machine* — see D2.
+
+*Enforced by:* the showcase itself.
+
+### D2 — A facility is not N cells
+
+**Decided.** Facility scale is a qualitative change, and the design must reflect all of it:
+
+- heterogeneous stations rather than replicated cells
+- physical samples moving between stations, with custody and genealogy
+- contention for shared characterization instruments
+- **multiple timescales in one loop** — minutes to weeks — so work pipelines rather than batches
+- graceful degradation when one station fails with dozens of experiments in flight
+- multi-fidelity triage: screen many, validate some, qualify few
+- human technicians as first-class stations for steps that cannot be automated
+
+Every one of these maps onto a primitive the framework already has and has never stressed: capability
+contracts, resource leases, lifecycle states and attestation, provenance, and the human-task
+adapter. That is the reason to build this rather than a bigger demo.
+
+*Enforced by:* intent, and by D9's framework work failing without it.
+
+### D3 — The 10x claim is decisions, not samples
+
+**Decided.** The capability claim is **experiments that reach a decision** — throughput × yield ×
+the fraction producing an attributable, trustworthy measurement — not samples per day.
+
+Samples per day is a weak claim because anyone can buy more liquid handlers. Real facilities lose
+most of their nominal throughput to samples that are made and never characterized, or characterized
+and never correctly attributed. That loss is what provenance actually fixes.
+
+*Enforced by:* the metric must appear in the showcase with a stated baseline. A claim without a
+denominator does not ship.
+
+### D4 — Scale invariance: the small case stays first-class
+
+**Decided, and load-bearing.** Facility work must not tax the one-bench case.
+
+The test for any new feature: **does it make the one-bench case better, or merely not worse?** A
+feature that only helps at scale is probably not a real concept — it is an accident of deployment
+promoted into the domain model. All four planned additions in D9 pass this test; anything that
+fails it should be redesigned rather than gated behind a flag.
+
+The hard constraint: **tier 1 must never require anything from tier 4.**
+
+| Tier | Storage | Process | Manifest |
+|---|---|---|---|
+| Laptop | SQLite | in-process | ~15 lines, `default_effect: allow` |
+| Bench | SQLite | in-process | adapters, real policy, campaigns |
+| Cell | SQLite | in-process | resources, twin, viewer |
+| Facility | PostgreSQL | multi-process | stations, long-latency work, human stations |
+
+*Enforced by:* `tests/test_minimal_laboratory.py`, which pins the size of the smallest working
+manifest and fails when the minimum grows. Growth in the minimum is the observable form of this
+decision being violated, and a new required field is a diff anyone can see.
+
+### D5 — The showcase proves the chain, not the loop
+
+**Decided.** The previous showcase proved a loop closes. That is no longer interesting. This one
+proves the chain from discovery to a sellable asset, in three visible beats:
+
+1. the loop finds something a grid search or a human would not have, with the search trace visible
+2. the evidence store becomes a qualification package automatically — **including the failed runs**,
+   because "what else did you try" is exactly the question provenance answers
+3. that package, not the material, is what a customer receives
+
+Beats 2 and 3 are the differentiation. Nobody is showing them.
+
+*Enforced by:* intent.
+
+### D6 — Target technology domain
+
+**Open.** Blocked on the domain research. The filter is fixed even though the answer is not:
+
+1. combinatorial **and** not already solved by simulation or ML on existing data
+2. loop-closable — real cost and wall-clock numbers per experiment
+3. characterization automatable, by a named instrument
+4. a named customer with a deadline, not a preference
+5. a survivable qualification timeline
+6. legible — a non-expert can see success
+
+Added by D2: the domain must have **genuine multi-step heterogeneity and a fast/slow split**. A
+domain where one instrument does everything is now a worse fit, because it would not exercise
+facility-scale capability.
+
+The disqualifying risk to check before committing: **does the fast screen actually predict the slow
+truth?** A fast proxy that does not predict the real property makes an autonomous lab a machine for
+generating confident error at speed. If the answer is no, the domain is rejected however good the
+science.
+
+### D7 — Business model
+
+**Open. Owner decision.** The candidates, with the known trade:
+
+- **joint development with an incumbent** — they hold the plant, customers and qualification muscle;
+  we hold search speed. Avoids the scale-up wall, caps the upside, makes us a supplier.
+- **discover and manufacture** — highest ceiling, and the wall Zymergen hit: a ~$3B valuation and
+  world-class automation, killed by a product with no qualified customer that could not scale.
+- **discover and license** — low capital, weak position; formulation IP is trade secret more than
+  patent.
+- **platform** — already what OpenSDL is, and it is open source.
+
+The hypothesis worth testing separately: tamper-evident provenance produces a **qualification
+dossier as a byproduct**, which in a regulatory-replacement market is itself a priced deliverable.
+That reframes the offer from "we found a molecule" to "we found it and can prove how, in a form a
+regulator accepts" — the second half being the defensible half.
+
+### D8 — Scheduler architecture
+
+**Open, and the sharpest tension in D4.** Facility scale wants a persistent process routing work
+across stations. The laptop case wants `opensdl run workflow.yaml` with no daemon, no broker, and
+nothing running in the background.
+
+Intended resolution: scheduling becomes a strategy behind an interface with an in-process
+immediate-dispatch default, in the same shape as the storage layer, where repository interfaces
+make PostgreSQL a swap rather than a rewrite. Named here because "we will just add a small daemon"
+is exactly how the small case dies.
+
+### D9 — Framework work the facility requires
+
+**Decided in shape, unscheduled.** Four additions, each of which must satisfy D4:
+
+1. **Long-latency capabilities.** A chamber that legitimately answers in three weeks is not a hung
+   instrument. Today a timeout on a non-repeatable capability lands in `intervention_required`,
+   which is right for a hung mixer and wrong for a chamber doing its job. "No answer yet" needs to
+   be a declared, normal state. *At one bench this fixes the overnight anneal.*
+2. **Late-arriving observations.** An observation must be foldable into a campaign whose run
+   finished long ago and which has since issued hundreds of proposals. *At one bench this is a
+   sample mailed out for external analysis.*
+3. **Multi-fidelity as a first-class concept.** A fast screen and a slow truth are different
+   measurements of one property, with different cost and trust, and the optimizer must know which
+   it received. The triage policy — which sample earns the expensive measurement — is where the
+   intellectual value sits and is the part a competitor cannot buy. *At one bench this is a cheap
+   check before an expensive one.*
+4. **Leases across long durations.** A chamber slot held for weeks stresses lease TTL,
+   reconciliation, and controller restart mid-hold.
+
+*Enforced by:* each ships with simulation and conformance coverage, per the architecture rules, and
+each must demonstrate its one-bench benefit in an example.
+
+### D10 — Dogfooding does not become facility-only
+
+**Decided.** Building the facility creates pressure for every default, example and document to
+assume one. The countermeasure is that the small examples stay alive and exercised.
+
+*Enforced by:* `make showcase` re-derives the `discovering-colors` campaign in CI, so the small
+reference cannot silently rot while attention is on the facility. The benchmark suite keeps both a
+small laboratory and a facility laboratory, so a change that makes small labs harder to operate
+appears as a score drop rather than a feeling.
+
+## Standing rules
+
+Durable constraints on all facility work. These are quoted in `AGENTS.md` so a fresh session
+inherits them.
+
+1. A laboratory with one instrument stays expressible in about fifteen manifest lines, runnable in
+   one process against SQLite, with no scheduler, no broker and no optional service.
+2. Facility features are opt-in by configuration, never by requirement.
+3. A change that lengthens the minimum manifest needs justifying.
+4. Heavy dependencies live behind an extra. `pip install opensdl` stays small.
+5. Documentation leads with the small case. The quick start never mentions a station.
+
+An accepted consequence: a feature that would be simple given PostgreSQL and a daemon will take
+longer built this way. That is the correct trade while the small case is the adoption path.
+
+## Sequence
+
+Phase boundaries, not dates. Each phase ends with something an outsider can check.
+
+**Phase 0 — settle the domain.** Close D6 and D7. Ends with a domain, a named customer, a
+loop with real cost and wall-clock numbers, and a written answer to the fast-screen-predicts-slow-
+truth question.
+
+**Phase 1 — framework work.** D9 items 1 and 2, each with a one-bench example. Ends with a campaign
+that keeps proposing while a three-week measurement is outstanding, demonstrated in simulation.
+
+**Phase 2 — the facility in simulation.** Stations, sample custody, contention, triage — as a
+manifest and a simulated laboratory, before any hardware. Ends with a facility that runs end to end
+with no physical equipment, which is also the honest way to size the real one.
+
+**Phase 3 — the twin.** The Blender scene of the facility, showing work in progress at every stage
+simultaneously. The multi-timescale story is legible at a glance in a way one plate cannot be.
+
+**Phase 4 — the chain.** D5 beats 2 and 3: the evidence store emitting a qualification package,
+failed runs included.
+
+**Phase 5 — real hardware.** Per the hardware access research: the first physical instrument, in
+whatever domain, closing one real loop.
+
+## Open questions
+
+| # | Question | Blocks | Owner |
+|---|---|---|---|
+| D6 | Which technology domain | Everything | research, then owner |
+| D7 | Business model | The plan's shape | owner |
+| D8 | Scheduler architecture | Phase 2 | design |
+| — | Does the fast screen predict the slow truth | D6 | research |
+| — | Facility capital and staffing | Phase 2 sizing | research |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Development:
       - development/index.md
       - Roadmap: development/roadmap.md
+      - Facility buildout: development/buildout.md
       - Development backlog: development/backlog.md
       - Repository audit 2026-08-05: development/audit-2026-08-05.md
       - Agent instructions and skills: development/agent-skills.md

--- a/tests/test_minimal_laboratory.py
+++ b/tests/test_minimal_laboratory.py
@@ -1,0 +1,103 @@
+"""The smallest laboratory that works must keep working, and keep being small.
+
+This is the enforcement mechanism for the scale-invariance decision in
+`docs/development/buildout.md`. Facility work must not tax the one-bench case, and the observable
+form of that promise being broken is the *minimum* growing: one new required field, one newly
+mandatory service, one more line nobody can omit.
+
+Nothing else in the suite would notice. Every other test declares a laboratory rich enough to
+exercise what it is testing, so a field becoming required is invisible until somebody with one
+instrument tries to start and cannot.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from opensdl_controller import OpenSDLSystem
+from opensdl_core import RunState, TaskState
+from opensdl_schemas import validate_manifest_file
+
+MINIMAL = Path(__file__).parents[1] / "examples" / "computation-only" / "opensdl.yaml"
+
+#: The smallest laboratory is 17 lines today. The headroom is deliberately thin: this number is
+#: meant to be argued with in review, not quietly absorbed. Raising it is a decision about who the
+#: framework is for, and `docs/development/buildout.md` asks that such a decision be justified.
+MANIFEST_LINE_LIMIT = 20
+
+
+def test_the_smallest_laboratory_stays_small() -> None:
+    """A required field added for facility scale would show up here first."""
+
+    lines = MINIMAL.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) <= MANIFEST_LINE_LIMIT, (
+        f"the minimal laboratory manifest is now {len(lines)} lines, over the {MANIFEST_LINE_LIMIT} "
+        "line limit. Something became required. See docs/development/buildout.md decision D4: "
+        "facility features are opt-in by configuration, never by requirement."
+    )
+
+
+def test_the_smallest_laboratory_still_validates() -> None:
+    """Line count catches creep; this catches a field becoming required without the file growing."""
+
+    validate_manifest_file(MINIMAL)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_the_smallest_laboratory_still_runs_work(tmp_path: Path) -> None:
+    """Small is not enough — it has to be a laboratory that does something.
+
+    Deliberately end to end against the real controller rather than a constructed system: what is
+    being checked is that no scheduler, broker, migration step or optional service crept into the
+    path between a fifteen-line manifest and executed work.
+    """
+    laboratory = tmp_path / "lab"
+    shutil.copytree(
+        MINIMAL.parent, laboratory, ignore=shutil.ignore_patterns(".opensdl", "__pycache__")
+    )
+
+    system = OpenSDLSystem.from_manifest(laboratory / "opensdl.yaml")
+    await system.start()
+    try:
+        run = await system.runtime.execute_capability(
+            "compute.euclidean_distance",
+            {"a": [0.0, 0.0], "b": [3.0, 4.0]},
+            environment="simulation",
+        )
+
+        assert [record.state for record in system.repositories.list_runs()] == [RunState.COMPLETED]
+        tasks = system.repositories.list_tasks(run.id)
+        assert [task.state for task in tasks] == [TaskState.SUCCEEDED]
+        # The arithmetic is checked so this is a laboratory that produced a right answer, rather
+        # than one that merely reached a terminal state without doing anything.
+        assert tasks[0].outputs["distance"] == pytest.approx(5.0)
+    finally:
+        await system.close()
+
+
+def test_the_smallest_laboratory_declares_no_optional_service() -> None:
+    """Tier 1 must never require anything from tier 4.
+
+    Checked against the manifest text rather than the parsed model on purpose: the failure this
+    guards against is a future field, and a parsed model can only be asked about fields that
+    already exist.
+    """
+    manifest = MINIMAL.read_text(encoding="utf-8").lower()
+
+    for service in (
+        "postgresql://",
+        "postgres://",
+        "redis",
+        "amqp",
+        "kafka",
+        "scheduler:",
+        "broker",
+    ):
+        assert service not in manifest, (
+            f"the minimal laboratory now mentions {service!r}. The smallest working laboratory runs "
+            "in one process against SQLite with no optional service. See buildout.md decision D4."
+        )


### PR DESCRIPTION
A canonical plan for facility-scale work, plus the test that keeps its central decision from decaying.

## Why a new document

The roadmap says what ships. The backlog says what remains. **Neither says what was decided or why**, so a decision survives only as long as the conversation that produced it.

This repository already demonstrates the failure mode: `audit-2026-08-05.md` is 945 lines of correct analysis whose own header records that nothing in it has been acted on.

So every decision in `docs/development/buildout.md` names the mechanism that would catch its violation — and an entry enforced only by intention says `Enforced by: intent`, because that is the honest description of its durability.

## The decisions captured

| | | |
|---|---|---|
| D1 | Facility scale, not another cell | decided |
| D2 | A facility is not N cells — seven qualitative differences | decided |
| D3 | The 10x claim is *experiments that reach a decision*, not samples/day | decided |
| **D4** | **Scale invariance — the small case stays first-class** | **decided, tested** |
| D5 | The showcase proves the chain to a sellable asset, not the loop | decided |
| D6 | Target domain | open — research |
| D7 | Business model | open — owner |
| D8 | Scheduler architecture | open — the sharpest tension in D4 |
| D9 | Framework work: long-latency capabilities, late observations, multi-fidelity, long leases | shaped |
| D10 | Dogfooding does not become facility-only | decided, enforced by `make showcase` |

## D4 is enforced, not asserted

The test for any facility feature: **does it make the one-bench case better, or merely not worse?** A feature that only helps at scale is usually not a real concept — it's an accident of deployment promoted into the domain model.

`tests/test_minimal_laboratory.py` makes that real. It pins the smallest working manifest (17 lines, limit 20), checks it still validates, runs real work through it end to end against the actual controller, and refuses any optional service.

**Verified failing as well as passing.** Adding a `scheduler:` and `stations:` block produces:

```
the minimal laboratory manifest is now 23 lines, over the 20 line limit.
Something became required. See docs/development/buildout.md decision D4.
```

Nothing else in the suite would have caught it. Every other test declares a laboratory rich enough to exercise what it's testing, so a field becoming required stays invisible until somebody with one instrument cannot start.

## Also

The scale rule is quoted in `AGENTS.md` alongside the other architecture rules, so a fresh session inherits it, with a pointer to the buildout doc.

## Gates

`make lint` 0 · `make test` **711 passed** · `make docs` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PcmK6wy24Fokk5hqtfH74