### PR TITLE
Record generation two, and the four tests it paid for

### DIFF
--- a/docs/development/buildout.md
+++ b/docs/development/buildout.md
@@ -101,9 +101,9 @@ Beats 2 and 3 are the differentiation. Nobody is showing them.
 
 ### D6 — Target technology domain
 
-**Open. Three candidates have been modelled to completion against adversarial review and
-falsified.** Each failed on arithmetic. The negative results are recorded because rediscovering them
-would cost months, and because the third one finally explains the first two.
+**Open. Seven candidates across two shapes have been modelled and falsified.** Each failed on
+arithmetic. The negative results are recorded because rediscovering them would cost months, and
+because a single mechanism accounts for all seven.
 
 **Falsified: a heavy-rare-earth-free permanent magnet venture.** The thesis was that grain-boundary
 engineering could reach high-temperature coercivity without dysprosium or terbium, removing the
@@ -175,18 +175,76 @@ Returns, probability-weighted over ten years: **2.03x selling adsorbent, 2.12x o
 for a staged hybrid**. Base-case IRRs are 5.6%, 10.2% and 15.1%. Owning plants carries the same
 expected multiple as selling beds, at four times the capital and a 50% probability of total loss.
 
-**What the three failures have in common, which is the useful result.** Every candidate was *a better
-material for a mature industrial process*. In a mature process the material axis is the cheapest axis
-to optimise, so incumbents harvested it first, over decades. What remains on that axis is the
-saturated tail — and the arithmetic keeps finding exactly that, because it is what is there. This is
-a structural property of the search. A fourth candidate of the same shape would produce a fourth
-version of the same answer.
+**Generation 1's diagnosis.** All three were *a better material for a mature industrial process*. In
+a mature process the material axis is the cheapest axis to optimise, so incumbents harvested it
+first, over decades, and what remains there is the saturated tail. The shape was changed to require
+that **the process does not yet exist**, so that material and process are designed together.
 
-The consequence for D6: the domain must be one where **the process does not yet exist**, so the
-material and the process are designed together and the material carries the whole value. That is also
-where an autonomous laboratory is differentiated. A facility is poor at extracting the last few
-percent from a fifty-year optimisation and strong at searching a space nobody has searched, because
-the measurement was too expensive to run at scale.
+**Generation 2 followed that instruction and produced four more falsifications.**
+
+| Candidate | Materials axis at its physical ceiling | The architecture that beat it, with no discovery |
+|---|---|---|
+| Elastocaloric cooling | +25-45% device COP; closes 4-13% of the gap to vapour compression | R-290 propane at $2/kg, +3% COP, full regulatory compliance |
+| CO2 or CO to ethylene | thermodynamic floor of 13,183 kWh/t | the BASF/SABIC/Linde electric cracker, running since April 2024 at 1,875-4,286 kWh/t |
+| On-site hydrogen peroxide | $40-99/t | Solvay deleting one distillation column, worth $500-1,000/t |
+| Direct propylene epoxidation | 11.6% cost share on the proponents' own arithmetic | Sumitomo's process, already cheaper on those same prices |
+
+The elastocaloric case is the sharpest. Take the material to *both* of its physical ceilings — zero
+hysteresis and transformation stress at the superelastic floor — and device coefficient of
+performance improves 25-45%. Parity with vapour compression requires **355-614%**. Between 58 and
+73% of the loss is pumps, friction, regenerator and heat leak. It is a mechanical engineering
+programme with a materials input.
+
+**The unified diagnosis, which is the actual result of five months of this.**
+
+> In all seven candidates, a process-architecture change on the same cost line beat the materials
+> discovery — including in the two where the process genuinely did not yet exist.
+
+The mechanism is structural. **Value that takes the form of reducing a loss is bounded below by zero
+loss, so it always saturates.** The incumbent has owned that cost line for decades and can move
+architecture far more cheaply than materials, so the cheap part is already gone. Four of the seven
+show the value function explicitly as `1 - x_ref/x`; a fifth shows it as the algebraically identical
+reciprocal sum `1/V = Σ 1/v_i`.
+
+Generation 2's instruction was necessary and insufficient, because it named the wrong noun. **A new
+process delivering an old product inherits the old product's saturated cost line intact.** Every one
+of the four obeyed the instruction and every one still chose a domain where the *product* already
+exists at industrial scale: cooling at 135 million units a year, ethylene at 200 Mt/y, hydrogen
+peroxide at 6.11 Mt/y, propylene oxide at 10 Mt/y.
+
+**The shape for generation 3:**
+
+> The discoverable property must gate whether a product or capability **exists at all**, and not how
+> efficiently an existing one is delivered.
+
+Two admissible criteria remain. **(a)** The product cannot currently be made at all, meaning there is
+no incumbent article to price against — a product that is merely expensive or dirty does not qualify.
+**(d)** A named buyer with a named budget and a named deadline needs something for which no supply
+route exists; if the buyer cannot be named, it is not criterion (d). Two criteria are retired: "the
+incumbent route is indirect" admits loss-reduction plays by construction and produced three of
+generation 2's four failures, and "a capability recently became cheap" describes the search rather
+than the value.
+
+One tension has to be resolved explicitly, because leaving it open is what produced the elastocaloric
+scissors — 92,148 t/y of demand in a market closed by propane, against 9-230 t/y in the market that
+is open. **If the product does not exist there is no world tonnage**, so the tonnage gate applies to a
+named substitution or new-demand pool with a named buyer, never to current sales.
+
+**The honest case against this whole approach, which is on the record because it may be right.** A
+screen that rejects everything is indistinguishable from a broken screen. These gates are calibrated
+on chemicals and energy, where incumbents have had fifty to a hundred years on every cost line that
+exists; applied to any mature industrial cost line they will reject everything, because that is what
+mature industrial cost lines look like. The screen may be correctly reporting that **no materials
+venture of any shape is fundable against a mature industrial cost line** — in which case the search
+space has to change, and a fourth shape would not help. Three further objections stand unanswered: seven of seven
+were killed by a prosecution with no symmetric defence, and asymmetric adversarial processes converge
+on rejection regardless of merit; every kill is a median-case kill, and a screen computing expected
+value on medians rejects every venture ever funded; and the exclusion of biology, in force for all
+seven, may have removed the answer from the search space before the search began, since a large share
+of genuine "cannot be made at all" opportunities now sit at the materials and biology interface.
+
+Generation 3 therefore adds a defence agent arguing each candidate as forcefully as the prosecution
+attacks it, with an adjudication between them.
 
 The filter is fixed even though the answer is not:
 
@@ -266,6 +324,40 @@ that governs under a sixth of the payer's cost cannot carry a venture outcome, h
 science is and however large the market. Market size does not rescue it, because the share is
 multiplicative with the market and the arithmetic is the same at every scale.
 
+**Four more tests, added after generation 2, in ascending order of cost.** Run them in this order and
+stop at the first failure. All seven falsified candidates would have died in under a day, and five of
+them in under an hour.
+
+**Test 0 — the value function. Free.** Can the customer buy an article today that performs the same
+function, in any form, at any price? If so the value is loss reduction, it saturates, and the
+candidate is rejected. Write the value function down. The form `V = C - K/x`, or a reciprocal sum
+`1/V = Σ 1/v_i`, is a rejection. The property must enter as a **threshold** — the article exists above
+the line and does not exist below it — or **multiplicatively into a quantity nobody currently sells**.
+
+**Test 1 — floor-limited cost. One hour.** When the dominant cost line is a purchased commodity whose
+coefficient has a thermodynamic floor, compute floor × price against product price before anything
+else. This alone kills a route that is underwater at its own physics limit, and it would have ended
+the ethylene candidate before any literature review.
+
+**Test 2 — physics-limit sufficiency. R ≥ 3.** Take the property to its physical ceiling and divide
+the improvement it delivers by the improvement required for parity with the **best architecture
+available to the incumbent**. Current practice is the wrong benchmark, because the incumbent will
+upgrade. The threshold is 3, because every prior candidate near or below 1 lost to an architecture
+change, and the margin has to absorb the pioneer-plant penalty: 51% of pioneer process plants never reach 85% of
+design capacity, and class-2 estimates come in 1.28× over.
+
+**Test 3 — architecture ratio. A < 0.3.** Divide the value of the best zero-discovery flowsheet change
+by the value of the materials axis at its ceiling. **This test has caught seven of seven**, which makes
+it the highest-yield screen in the set for the time it takes. Search the flowsheet literature:
+debottlenecking, modular plants, electrified heat, an eliminated unit operation, and the licensor
+patent record.
+
+**Test 4 — capital benchmarked from outside the field. Half a day.** Never price capital from a
+field's own techno-economic analyses, because every field's analyses carry its own aspirations. Price
+against the nearest mature technology's demonstrated installed cost. One candidate's literature
+assumed $68/kW against a roughly $2,000/kW demonstrated baseline for a strictly harder device — a
+factor of thirty, hiding inside peer review.
+
 The related trap, which the para-xylene work names precisely: **the number the literature reports is
 often not the number that sets cost.** The field reports gravimetric equilibrium selectivity on powder
 against a binary feed. Plant cost is set by volumetric working capacity and mass-transfer rate on a
@@ -273,7 +365,10 @@ formed bead in four-component feed with a desorbent present. One material bought
 paid 39% of its capacity; a nine-formulation dataset spans 55.3 to 88.5 wt% selectivity with a 2.45x
 throughput spread that tracks macropore volume, and the most selective sample is not the fastest.
 Confirm that the reported measurement is the one that governs cost before treating a literature
-record as a prize.
+record as a prize. Check the **sign** of the correlation between the cheap assay and the expensive
+truth in the variable that must change at scale. A correlation that merely exists is insufficient.
+One generation-2 candidate had a screen that was worse than useless: selectivity fell with the pressure
+the commercial plant would require, so the bench result pointed the wrong way.
 
 *Enforced by:* `tests/test_domain_proposal.py`. A domain proposal is one Markdown file in
 [`docs/development/domains/`](domains/index.md), and the suite fails if it omits any screen section,

--- a/docs/development/domains/_template.md
+++ b/docs/development/domains/_template.md
@@ -7,6 +7,34 @@
 One paragraph: what the laboratory searches for, and what exists at the end of the search that does
 not exist today.
 
+## Value function
+
+**Test 0, and it is free.** Can the customer buy an article today that performs the same function, in
+any form, at any price? If so the value is loss reduction, which is bounded below by zero loss and
+therefore saturates — and the incumbent, who owns that cost line, can move process architecture far
+more cheaply than materials. Seven candidates died here.
+
+Write the value function down. `V = C − K/x`, or a reciprocal sum `1/V = Σ 1/v_i`, is a rejection.
+State the form as a **threshold** — the article exists above the line and does not exist below it —
+or as **multiplicative** into a quantity nobody currently sells.
+
+## Physics-limit sufficiency
+
+**Test 2. R ≥ 3.** Take the discoverable property to its physical ceiling. Divide the improvement it
+delivers by the improvement required for parity with the best architecture available to the
+incumbent. Current practice is the wrong benchmark, because the incumbent will upgrade.
+
+The threshold is 3 so the margin can absorb the pioneer-plant penalty: 51% of pioneer process plants
+never reach 85% of design capacity, and class-2 estimates come in 1.28× over.
+
+## Architecture ratio
+
+**Test 3. A < 0.3, and this check has caught seven of seven.** Divide the value of the best
+zero-discovery flowsheet change by the value of the materials axis at its ceiling. Ask what the
+incumbent's process engineers could do to the same cost line with no discovery at all, and price it.
+
+Search the flowsheet literature and the licensor patent record, and name what you found.
+
 ## Controlled cost share
 
 **The screen. Answer it first, and answer it with arithmetic.** What percentage of the paying

--- a/docs/development/domains/index.md
+++ b/docs/development/domains/index.md
@@ -5,10 +5,12 @@ directory. The proposal exists so the screen in
 [decision D12](../buildout.md#d12-screen-the-cost-share-before-spending-research-on-a-domain) runs
 before research money does.
 
-Three candidates were each researched to completion and each died on the same question, asked at the
-end: what fraction of the paying customer's cost does the discoverable property actually control?
-The answers were 1.3%, 2.4-4.1%, and a figure that fell fourfold under recomputation. Each was
-estimable in an afternoon from public cost structure.
+Seven candidates were each researched to completion and each died of the same thing: **a process
+architecture change on the same cost line beat the materials discovery**, including in the two cases
+where the process genuinely did not yet exist. Value that reduces a loss is bounded below by zero
+loss, so it saturates, and the incumbent has owned that cost line for decades.
+
+Every one of the seven was killable in under a day, and five of them in under an hour.
 
 Start from [the template](_template.md), which carries every required heading and the reason each
 one is there.
@@ -20,6 +22,9 @@ again if the controlled cost share is stated without a percentage or falls below
 
 | Section | The question it answers | Decision |
 |---|---|---|
+| Value function | Can the customer buy an article today that does the same job? If so the value saturates. State the form: threshold, or multiplicative into an unsold quantity. | D12, test 0 |
+| Physics-limit sufficiency | The property at its ceiling, divided by what parity with the incumbent's best available architecture requires. R ≥ 3. | D12, test 2 |
+| Architecture ratio | The best zero-discovery flowsheet change, divided by the materials axis at its ceiling. A < 0.3. This check has caught seven of seven. | D12, test 3 |
 | Controlled cost share | What percentage of the payer's cost does the discoverable property govern? Show the arithmetic. | D12 |
 | Process maturity | Does a mature incumbent process already exist that this would merely improve? | D6 |
 | Annual tonnage | World annual tonnage of the addressable output, with a source. | D6 |

--- a/tests/test_domain_proposal.py
+++ b/tests/test_domain_proposal.py
@@ -34,7 +34,14 @@ REQUIRED_SECTIONS = {
     "measurement identity": "D12 — the reported number must be the number that sets cost",
     "fast screen predicts slow truth": "D6 — otherwise the facility generates confident error fast",
     "capital intensity": "D11 — discovery value per unit against capital charge per unit",
+    "value function": "D12 test 0 — loss reduction saturates, so the form decides the answer",
+    "architecture ratio": "D12 test 3 — the check that caught seven of seven",
+    "physics-limit sufficiency": "D12 test 2 — the property at its ceiling against what parity needs",
 }
+
+#: The two value-function forms that survive. Anything the customer can already buy in some form is
+#: loss reduction, whose value is bounded below by zero loss and therefore saturates.
+PASSING_VALUE_FORMS = ("threshold", "multiplicative")
 
 #: The cost share must be stated as a number, because "high" is what got skipped three times.
 COST_SHARE_FIGURE = re.compile(r"(\d+(?:\.\d+)?)\s*%")
@@ -93,6 +100,29 @@ def test_the_controlled_cost_share_is_a_number(proposal: Path) -> None:
         f"{proposal.name} reports a controlled cost share of {max(figures)}%, below the 15% floor "
         "in decision D12. A property governing under a sixth of the payer's cost cannot carry a "
         "venture outcome, however good the science is."
+    )
+
+
+@pytest.mark.parametrize("proposal", proposals(), ids=lambda path: path.stem)
+def test_the_value_function_is_not_loss_reduction(proposal: Path) -> None:
+    """The check that seven falsified candidates would each have failed for free.
+
+    Every one of them reduced a loss on a cost line the incumbent already owned. Value of that shape
+    is bounded below by zero loss, so it saturates, and the incumbent can move process architecture
+    far more cheaply than materials. The property has to decide whether the article exists.
+    """
+
+    text = proposal.read_text(encoding="utf-8")
+    lowered = text.lower()
+    start = lowered.find("value function")
+    if start < 0:
+        pytest.skip("no value function section; the missing-section test reports this")
+    section = lowered[start : start + 2000]
+
+    assert any(form in section for form in PASSING_VALUE_FORMS), (
+        f"{proposal.name} does not state its value function as a threshold or as multiplicative into "
+        "a quantity nobody currently sells. Every falsified candidate reduced a loss instead, and "
+        "loss reduction is bounded below by zero loss. See decision D12, test 0."
     )
 
 


### PR DESCRIPTION
Four more candidates modelled to completion and killed. Seven now, across two shapes — and one
mechanism accounts for all seven.

| Candidate | Materials axis at its physical ceiling | The architecture that beat it, with no discovery |
|---|---|---|
| Elastocaloric cooling | +25-45% device COP; closes 4-13% of the gap | R-290 propane at $2/kg, +3% COP, full compliance |
| CO2 or CO to ethylene | thermodynamic floor of 13,183 kWh/t | BASF/SABIC/Linde electric cracker, live since April 2024, 1,875-4,286 kWh/t |
| On-site hydrogen peroxide | $40-99/t | Solvay deleting one distillation column, $500-1,000/t |
| Direct propylene epoxidation | 11.6% cost share on the proponents' own arithmetic | Sumitomo, already cheaper on those same prices |

**The diagnosis.** In all seven, a process-architecture change on the same cost line beat the
materials discovery — including in the two where the process genuinely did not yet exist. Value that
reduces a loss is bounded below by zero loss, so it saturates. Four of the seven show the value
function explicitly as `1 - x_ref/x`; a fifth shows the algebraically identical reciprocal sum.

Generation 2's instruction named the wrong noun: a new process delivering an old product inherits
the old product's saturated cost line. All four obeyed it and all four still picked a domain whose
*product* already ships at industrial scale.

**D12 gains four tests, in ascending order of cost.** Test 0 is free and would have killed all seven:
write the value function down, and reject `V = C - K/x`. Test 3, the architecture ratio, has caught
seven of seven. `tests/test_domain_proposal.py` now requires a proposal to declare its value function
as a threshold or as multiplicative into a quantity nobody currently sells.

**The honest case against is recorded too**, because it may be right: a screen that rejects
everything is indistinguishable from a broken one, all seven were killed by a prosecution with no
symmetric defence, every kill is a median-case kill, and the exclusion of biology may have removed
the answer before the search began.

`make lint`, `make test` (712 passed), `make docs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D474cFdhB3DeTu2sKt7VuE