### PR TITLE
Keep the two facility designs the dead ventures paid for

### DIFF
--- a/docs/development/buildout.md
+++ b/docs/development/buildout.md
@@ -49,7 +49,25 @@ Every one of these maps onto a primitive the framework already has and has never
 contracts, resource leases, lifecycle states and attestation, provenance, and the human-task
 adapter. That is the reason to build it.
 
-*Enforced by:* intent, and by D9's framework work failing without it.
+**Two worked reference designs.** The domain search produced two facility architectures that are
+worth keeping even though both ventures were falsified. They are the concrete form of the list above,
+researched to real instruments, real costs and real wall-clock.
+
+*Elastocaloric alloys.* Nine steps from melt to regenerator assembly. Differential scanning
+calorimetry answers in **15 minutes at $10 a sample**; functional fatigue to 10⁸ cycles takes
+**58 days at $15,000-30,000**. That is a **fast/slow ratio of about 5,500**. The contended instruments
+are servo-hydraulic and resonant frames, which every fatigue campaign queues on, plus electron
+backscatter diffraction, transmission electron microscopy, and a single regenerator rig. Custody runs
+melt → work → heat treat → machine → coupon test → tube form → assembly, with a specific ingot heat
+traceable through six operations.
+
+*CO2 electrolysis.* **Five decades of timescale in one workflow**: cyclic voltammetry in 10-60
+minutes under $5; Faradaic efficiency on a small electrode in 2-6 hours; a 25 cm² membrane assembly
+for 100 hours over 4-7 days; 1,000-hour durability at 100 cm² holding a stand for six weeks; then an
+8,760-hour qualification occupying one stand for a year. The throughput bottleneck is the gas
+chromatography and mass spectrometry product line, which every cell needs continuously.
+
+Both are kept as reference designs for facility shape. Neither is a domain recommendation.
 
 ### D3 — The 10x claim is decisions per unit time
 
@@ -379,6 +397,58 @@ A convention-based check has an obvious hole: write the proposal somewhere else 
 runs. That hole is closed at the one place it matters. A third check reads D6 itself, and if this
 entry stops reading as open it must link to a proposal file that exists — so a domain choice cannot
 be recorded in the decision log without a document the screen has already been applied to.
+
+### D13 — The facility's first deliverable is the predictive bridge
+
+**Decided. It came from the two facility architectures; neither venture survived to contribute it.**
+
+Both domains examined in enough depth to answer the question gave the same answer, and it was the
+answer that disqualifies a naive facility:
+
+> **The fast screen does not predict the slow truth, and no validated accelerated protocol exists.**
+
+For elastocaloric alloys, differential scanning calorimetry genuinely predicts adiabatic temperature
+change, and an infrared self-heating method genuinely predicts *structural* fatigue to 10⁷ cycles.
+Neither predicts *functional* fatigue, which is what actually kills a regenerator, and single-cycle
+adiabatic temperature change **overstates the stabilised value by 1.5 to 6 times** (23-38.5 K
+measured against 6.6-15.9 K after fatigue). The field's fastest screen also measures the wrong
+object: the celebrated 10⁷-cycle result is a sputtered 20 µm film, and **eleven years later no bulk
+material reproduces that fatigue life at that temperature change.**
+
+For CO2 electrolysis, a one-hour flow-cell efficiency of 75.9% does not predict a 1,020-hour
+membrane-assembly efficiency of 68% at one sixth the current density. Every degradation mode — salt
+precipitation, flooding, copper reconstruction, ionomer and membrane decay — is slow and invisible in
+an hour. The published literature on accelerated testing for this device is one position paper from
+2020 and nothing standardised since.
+
+**A facility that scales the fast screen without the bridge is a machine for generating confident
+error at speed.** D6 already lists this as a disqualifying risk for a domain. D13 states the
+consequence for the build: **the bridge is the facility's first deliverable, before any discovery
+campaign runs.**
+
+Three things follow.
+
+1. **The bridge is measurement science.** It is bounded, schedulable and estimable in a way discovery
+   is not. The elastocaloric version is a bulk-coupon assay under 10⁴ cycles calibrated against
+   10⁷-cycle behaviour on a formed article; at 20 Hz a 10⁷-cycle point takes 5.8 days, so a 40-point
+   calibration set is about eight months on four frames or two months on twenty.
+2. **The bridge is a saleable asset on its own.** It is transferable, it serves every participant in
+   the field including competitors, and it needs no plant, no offtake and no first-of-a-kind
+   financing. D7's qualification-dossier hypothesis is the same idea seen from the commercial side.
+3. **It changes what the facility is claimed to do.** The claim "we search faster" is weaker and
+   easier to attack than the claim "we built the measurement that makes searching mean anything,"
+   and only the second is defensible when the field's own fast screen points the wrong way.
+
+**One uncomfortable finding to keep with it.** Model contribution is largest where it is least needed.
+On cheap axes — transformation temperature, latent heat, hysteresis — models do well. On the
+expensive axis that decides the outcome, fatigue life scatters by an order of magnitude at fixed
+nominal condition, which sits at the bad end of the 2.3-3.5x noise penalty, and each point costs 6 to
+58 days. So the realistic acceleration is near the bottom of the published 1.25-6x band **on the axis
+that matters**. State that to an investor plainly, because it is the first thing a good one will find.
+
+*Enforced by:* intent, and by D6's existing requirement that a domain answer the
+fast-screen-predicts-slow-truth question before adoption. `tests/test_domain_proposal.py` requires
+the answer to be present and to state the sign of the correlation.
 
 ### D7 — Business model
 

--- a/docs/development/domains/_template.md
+++ b/docs/development/domains/_template.md
@@ -85,7 +85,12 @@ What is the cheap measurement, what is the expensive one, and what evidence says
 the second? Without that, the facility is a machine for generating confident error at speed, and the
 domain is rejected however good the science is.
 
-Note whether the expensive measurement can be truncated rather than merely scheduled around.
+**State the sign of the correlation** in the variable that must change at scale. A correlation that
+merely exists is insufficient: one falsified candidate had selectivity falling with the pressure its
+plant required, so a better bench number predicted a worse plant.
+
+Note whether the expensive measurement can be truncated as well as scheduled around, and say what the
+bridge costs to build — decision D13 makes it the facility's first deliverable.
 
 ## Capital intensity
 

--- a/docs/development/domains/index.md
+++ b/docs/development/domains/index.md
@@ -31,7 +31,7 @@ again if the controlled cost share is stated without a percentage or falls below
 | Attribution distance | How many transformation layers sit between the advance and the payer? | D6 |
 | Computational regime | SOLVED, PARTIAL or BLIND. Only PARTIAL qualifies. | D6 |
 | Measurement identity | Is the number the literature reports the number that sets cost? | D12 |
-| Fast screen predicts slow truth | Does the cheap measurement genuinely predict the expensive one? | D6 |
+| Fast screen predicts slow truth | Does the cheap measurement genuinely predict the expensive one, and **with which sign** in the variable that must change at scale? | D6, D13 |
 | Capital intensity | Discovery value per unit of output against capital charge per unit of output. | D11 |
 
 ## The check that closes the convention's hole

--- a/tests/test_domain_proposal.py
+++ b/tests/test_domain_proposal.py
@@ -126,6 +126,28 @@ def test_the_value_function_is_not_loss_reduction(proposal: Path) -> None:
     )
 
 
+@pytest.mark.parametrize("proposal", proposals(), ids=lambda path: path.stem)
+def test_the_fast_screen_answer_states_the_sign(proposal: Path) -> None:
+    """A correlation that exists is not enough; it has to point the right way.
+
+    One falsified candidate had a screen that was worse than useless. Selectivity fell with the
+    pressure the commercial plant would require, so a better bench number predicted a worse plant.
+    Both facility architectures examined in depth had a fast screen that failed to predict the slow
+    truth, which is why decision D13 makes the bridge the first deliverable.
+    """
+
+    text = proposal.read_text(encoding="utf-8").lower()
+    start = text.find("fast screen predicts slow truth")
+    if start < 0:
+        pytest.skip("no fast screen section; the missing-section test reports this")
+    section = text[start : start + 2500]
+
+    assert "sign" in section, (
+        f"{proposal.name} does not state the sign of the correlation between the cheap assay and the "
+        "expensive truth, in the variable that must change at scale. See decision D13."
+    )
+
+
 #: The decision log's own entry for the domain choice. Parsed so that recording a chosen domain
 #: requires a proposal that passed the screen above.
 BUILDOUT = Path(__file__).parents[1] / "docs" / "development" / "buildout.md"


### PR DESCRIPTION
Both generation-2 domains examined deeply enough to answer the question gave the same answer, and it
is the one that disqualifies a naive facility:

> **The fast screen does not predict the slow truth, and no validated accelerated protocol exists.**

*Elastocaloric.* Differential scanning calorimetry genuinely predicts adiabatic temperature change,
and an infrared self-heating method genuinely predicts *structural* fatigue to 10⁷ cycles. Neither
predicts *functional* fatigue, which is what actually kills a regenerator, and single-cycle values
overstate the stabilised ones by **1.5 to 6 times** (23–38.5 K against 6.6–15.9 K after fatigue). The
field's fastest screen measures a sputtered 20 µm film that **no bulk material has reproduced in
eleven years**.

*CO₂ electrolysis.* A one-hour flow-cell efficiency of 75.9% does not predict a 1,020-hour membrane
result of 68% at one sixth the current density. Every degradation mode is slow and invisible in an
hour, and the published literature on accelerated testing is one 2020 position paper.

**D13 states the consequence: the bridge is the facility's first deliverable, before any discovery
campaign runs.** It is measurement science, so it is bounded and schedulable. It sells on its own —
no plant, no offtake, no first-of-a-kind financing. And it replaces "we search faster" with a claim
that survives contact with a field whose own fast screen points the wrong way.

**D2 gains both architectures as reference designs**: a 5,500× fast/slow ratio across nine steps with
six-operation custody, and five decades of timescale bottlenecked on a single GC/MS line. Neither is
a domain recommendation.

Recorded with the uncomfortable part — model contribution is largest on the cheap axes and smallest
on the expensive axis that decides the outcome, because noise scales with the measurement that costs
6 to 58 days per point.

`tests/test_domain_proposal.py` now also requires a proposal to state the **sign** of the fast-screen
correlation, since one falsified candidate had selectivity falling with the pressure its plant
required.

`make lint`, `make test` (712 passed), `make docs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D474cFdhB3DeTu2sKt7VuE