### PR TITLE
Catch the contrast variant that hides from the search

### DIFF
--- a/WRITING-RULES.md
+++ b/WRITING-RULES.md
@@ -44,7 +44,7 @@ of an actual campaign existed.
 **Superseded:** 2026-08-11 — the original rule read "show the run, not the machine" and moved the
 campaign frame to the header. Sean reversed it: the cell is the header, and the campaign frame comes
 later as an example. The narrower rule above is what survives — prefer the run *where the run is the
-subject*, rather than everywhere.
+subject*. Everywhere was too broad.
 
 ## Size an image for where it is read
 
@@ -58,8 +58,13 @@ resampled to 1920px read sharp.
 ## Never manufacture emphasis with a contrast
 
 **Rule:** Do not use the formulaic contrast: `X, not Y` · `not X but Y` · `X rather than Y` ·
-`X instead of Y` · `less X, more Y`. State the claim and stop. Where the contrast carries real
-information, give it its own sentence and say what is actually true of the rejected option.
+`X instead of Y` · `less X, more Y` · `it is not X; it is Y`. State the claim and stop. Where the
+contrast carries real information, give it its own sentence and say what is actually true of the
+rejected option.
+
+The last variant hides from a search for the others, and it survived two passes over the buildout
+page. A comparison of two real quantities is fine — moving process architecture genuinely does cost
+less than moving materials. The rule is about inventing a foil in order to sound emphatic.
 
 **Why:** The construction invents a strawman to knock down, which reads as emphasis without adding
 information. It is one of the most reliable signals of generated prose, and it accumulates: the

--- a/docs/development/buildout.md
+++ b/docs/development/buildout.md
@@ -10,6 +10,8 @@ changes. It holds **decisions and their reasoning**, which nothing else in the r
 
 - [The roadmap](roadmap.md) tracks releases. It says what ships.
 - [The backlog](backlog.md) tracks framework work items. It says what remains.
+- [Domain proposals](domains/index.md) hold candidate technology domains, one file each, against the
+  screen in D12. D6 cannot record a choice without one.
 - This page tracks the program. It says **what was decided and why**, so a decision survives the
   conversation that produced it.
 
@@ -29,7 +31,7 @@ means nothing would catch it, which is a standing invitation to find a better me
 **Decided.** The next showcase is a laboratory facility. A single cell has already been shown.
 
 A single cell has already been demonstrated and a second one proves nothing new. The interesting
-claim is not more throughput; it is that a facility is a *different machine* — see D2.
+claim is that a facility is a *different machine* — see D2. Throughput alone would prove little.
 
 *Enforced by:* the showcase itself.
 


### PR DESCRIPTION
`it is not X; it is Y` is the same construction wearing a semicolon, and it survived two passes
because a grep for the listed forms does not find it. Added to the rule in `WRITING-RULES.md`, and
the one surviving instance removed from D1.

The rule note now also says what is **not** banned, because the last pass nearly deleted a true
comparison: moving process architecture genuinely does cost less than moving materials. The rule is
about inventing a foil in order to sound emphatic, and a comparison of two real quantities is fine.

The buildout page's own map of the documentation now lists `docs/development/domains/`, which D6
depends on and which was previously reachable only from D12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D474cFdhB3DeTu2sKt7VuE