### PR TITLE
A harness that builds a Blender scene and hands back a bindable twin

### DIFF
--- a/scripts/openrouter_bridge.py
+++ b/scripts/openrouter_bridge.py
@@ -37,6 +37,14 @@ UPSTREAM = os.environ.get(
 )
 
 #: Anthropic stop reasons keyed by the OpenAI finish reason that means the same thing.
+#: GLM 5.3 Flash does not stop reasoning on its own. Left alone it spends the whole completion
+#: budget thinking and returns `finish_reason="length"` with zero content, which reads as the model
+#: having nothing to say. Measured on one Blender brief: plain, 143s and 6000 tokens of reasoning
+#: for 0 bytes of answer; with this flag, 34s and 2181 bytes. It still reasons — the flag excludes
+#: the trace from the response — but it now yields an answer. `{"enabled": false}` is rejected by
+#: the provider outright.
+REASONING = {"exclude": True}
+
 STOP_REASONS = {
     "stop": "end_turn",
     "length": "max_tokens",
@@ -150,6 +158,7 @@ def to_openai(payload: dict[str, Any], model: str) -> dict[str, Any]:
         "model": model,
         "messages": messages,
         "max_tokens": payload.get("max_tokens", 32000),
+        "reasoning": REASONING,
     }
     if "temperature" in payload:
         request["temperature"] = payload["temperature"]

--- a/scripts/openrouter_bridge.py
+++ b/scripts/openrouter_bridge.py
@@ -149,7 +149,7 @@ def to_openai(payload: dict[str, Any], model: str) -> dict[str, Any]:
     request: dict[str, Any] = {
         "model": model,
         "messages": messages,
-        "max_tokens": payload.get("max_tokens", 8192),
+        "max_tokens": payload.get("max_tokens", 32000),
     }
     if "temperature" in payload:
         request["temperature"] = payload["temperature"]
@@ -183,6 +183,21 @@ def to_anthropic_blocks(message: dict[str, Any]) -> list[dict[str, Any]]:
     text = message.get("content")
     if isinstance(text, str) and text.strip():
         blocks.append({"type": "text", "text": text})
+    elif not message.get("tool_calls"):
+        # A reasoning model that exhausts its budget mid-thought returns content=None with no
+        # tool call. Surfacing the reasoning is more useful to the harness than an empty turn,
+        # which reads as the model having nothing to say.
+        thought = message.get("reasoning")
+        if isinstance(thought, str) and thought.strip():
+            blocks.append(
+                {
+                    "type": "text",
+                    "text": (
+                        "[the model ran out of output budget while reasoning; its trace ended]\n\n"
+                        + thought[-2000:]
+                    ),
+                }
+            )
     for call in message.get("tool_calls") or []:
         function = call.get("function") or {}
         raw = function.get("arguments") or "{}"

--- a/scripts/openrouter_bridge.py
+++ b/scripts/openrouter_bridge.py
@@ -1,0 +1,460 @@
+"""Serve the Anthropic Messages API on top of OpenRouter, so any model can run in this harness.
+
+Claude Code speaks one protocol and honours `ANTHROPIC_BASE_URL`, which was verified by pointing it
+at a listener and watching it POST `/v1/messages?beta=true`. OpenRouter speaks OpenAI chat
+completions. This is the translation between them, in the standard library, so it starts with
+`python3 scripts/openrouter_bridge.py` and nothing else.
+
+    OPENROUTER_API_KEY=... python3 scripts/openrouter_bridge.py --model z-ai/glm-5.3-flash
+    ANTHROPIC_BASE_URL=http://127.0.0.1:8899 ANTHROPIC_API_KEY=unused claude -p "..."
+
+**Upstream calls are not streamed, downstream responses are.** Claude Code wants server-sent events;
+OpenRouter is asked for a whole response and the events are synthesised from it. That trades first
+token latency for not having to reassemble partial tool-call JSON across chunk boundaries, which is
+where this class of bridge usually breaks. For an agent loop, where the next action waits on the
+whole message anyway, that is the right side of the trade.
+
+What is deliberately not handled: prompt caching hints, thinking blocks, and citations. They are
+dropped rather than faked, because a bridge that silently invents a capability is worse than one
+that plainly lacks it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+#: Overridable so the bridge can be tested against a local fake without a live key.
+UPSTREAM = os.environ.get(
+    "OPENROUTER_COMPLETIONS_URL", "https://openrouter.ai/api/v1/chat/completions"
+)
+
+#: Anthropic stop reasons keyed by the OpenAI finish reason that means the same thing.
+STOP_REASONS = {
+    "stop": "end_turn",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
+    "function_call": "tool_use",
+    "content_filter": "end_turn",
+}
+
+
+# --------------------------------------------------------------------------- request translation
+
+
+def _system_text(system: Any) -> str:
+    """Anthropic allows a bare string or a list of blocks. OpenAI wants one string."""
+
+    if isinstance(system, str):
+        return system
+    if isinstance(system, list):
+        return "\n\n".join(
+            str(block.get("text", "")) for block in system if isinstance(block, dict)
+        )
+    return ""
+
+
+def _content_parts(content: Any) -> list[dict[str, Any]]:
+    """Text and image blocks, in OpenAI's shape. Other block types are handled by the caller."""
+
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    parts: list[dict[str, Any]] = []
+    for block in content if isinstance(content, list) else []:
+        if not isinstance(block, dict):
+            continue
+        kind = block.get("type")
+        if kind == "text":
+            parts.append({"type": "text", "text": block.get("text", "")})
+        elif kind == "image":
+            source = block.get("source") or {}
+            if source.get("type") == "base64":
+                media = source.get("media_type", "image/png")
+                data = source.get("data", "")
+                parts.append(
+                    {"type": "image_url", "image_url": {"url": f"data:{media};base64,{data}"}}
+                )
+            elif source.get("type") == "url":
+                parts.append({"type": "image_url", "image_url": {"url": source.get("url", "")}})
+    return parts
+
+
+def to_openai(payload: dict[str, Any], model: str) -> dict[str, Any]:
+    """One Anthropic Messages request, as an OpenAI chat completion request."""
+
+    messages: list[dict[str, Any]] = []
+    system = _system_text(payload.get("system"))
+    if system:
+        messages.append({"role": "system", "content": system})
+
+    for message in payload.get("messages", []):
+        role = message.get("role", "user")
+        content = message.get("content")
+
+        # A user turn carrying tool results becomes one OpenAI `tool` message per result.
+        if isinstance(content, list):
+            tool_results = [
+                b for b in content if isinstance(b, dict) and b.get("type") == "tool_result"
+            ]
+            for result in tool_results:
+                body = result.get("content")
+                if isinstance(body, list):
+                    body = "\n".join(
+                        str(part.get("text", "")) for part in body if isinstance(part, dict)
+                    )
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": result.get("tool_use_id", ""),
+                        "content": str(body if body is not None else ""),
+                    }
+                )
+
+            tool_uses = [b for b in content if isinstance(b, dict) and b.get("type") == "tool_use"]
+            parts = _content_parts(
+                [b for b in content if b not in tool_results and b not in tool_uses]
+            )
+
+            if tool_uses:
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": "".join(p["text"] for p in parts if p.get("type") == "text")
+                        or None,
+                        "tool_calls": [
+                            {
+                                "id": use.get("id", f"call_{uuid.uuid4().hex[:8]}"),
+                                "type": "function",
+                                "function": {
+                                    "name": use.get("name", ""),
+                                    "arguments": json.dumps(use.get("input") or {}),
+                                },
+                            }
+                            for use in tool_uses
+                        ],
+                    }
+                )
+            elif parts:
+                messages.append({"role": role, "content": parts})
+        elif content:
+            messages.append({"role": role, "content": content})
+
+    request: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": payload.get("max_tokens", 8192),
+    }
+    if "temperature" in payload:
+        request["temperature"] = payload["temperature"]
+
+    tools = payload.get("tools") or []
+    translated = [
+        {
+            "type": "function",
+            "function": {
+                "name": tool.get("name", ""),
+                "description": tool.get("description", "")[:1024],
+                "parameters": tool.get("input_schema") or {"type": "object", "properties": {}},
+            },
+        }
+        for tool in tools
+        if isinstance(tool, dict) and tool.get("name")
+    ]
+    if translated:
+        request["tools"] = translated
+        request["tool_choice"] = "auto"
+    return request
+
+
+# -------------------------------------------------------------------------- response translation
+
+
+def to_anthropic_blocks(message: dict[str, Any]) -> list[dict[str, Any]]:
+    """An OpenAI assistant message, as Anthropic content blocks."""
+
+    blocks: list[dict[str, Any]] = []
+    text = message.get("content")
+    if isinstance(text, str) and text.strip():
+        blocks.append({"type": "text", "text": text})
+    for call in message.get("tool_calls") or []:
+        function = call.get("function") or {}
+        raw = function.get("arguments") or "{}"
+        try:
+            parsed = json.loads(raw) if isinstance(raw, str) else raw
+        except json.JSONDecodeError:
+            parsed = {"_unparsed_arguments": raw}
+        blocks.append(
+            {
+                "type": "tool_use",
+                "id": call.get("id") or f"toolu_{uuid.uuid4().hex[:16]}",
+                "name": function.get("name", ""),
+                "input": parsed if isinstance(parsed, dict) else {"value": parsed},
+            }
+        )
+    if not blocks:
+        blocks.append({"type": "text", "text": ""})
+    return blocks
+
+
+def sse_events(blocks: list[dict[str, Any]], stop_reason: str, usage: dict[str, Any], model: str):
+    """The Anthropic stream, synthesised whole. Each yielded item is one `event:`/`data:` pair."""
+
+    message_id = f"msg_{uuid.uuid4().hex[:24]}"
+
+    def event(name: str, body: dict[str, Any]) -> str:
+        return f"event: {name}\ndata: {json.dumps(body)}\n\n"
+
+    yield event(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": message_id,
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {
+                    "input_tokens": int(usage.get("prompt_tokens", 0)),
+                    "output_tokens": 0,
+                },
+            },
+        },
+    )
+
+    for index, block in enumerate(blocks):
+        if block["type"] == "text":
+            yield event(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            )
+            if block["text"]:
+                yield event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": index,
+                        "delta": {"type": "text_delta", "text": block["text"]},
+                    },
+                )
+        else:
+            yield event(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": index,
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": block["id"],
+                        "name": block["name"],
+                        "input": {},
+                    },
+                },
+            )
+            yield event(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": {
+                        "type": "input_json_delta",
+                        "partial_json": json.dumps(block["input"]),
+                    },
+                },
+            )
+        yield event("content_block_stop", {"type": "content_block_stop", "index": index})
+
+    yield event(
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+            "usage": {"output_tokens": int(usage.get("completion_tokens", 0))},
+        },
+    )
+    yield event("message_stop", {"type": "message_stop"})
+
+
+# ------------------------------------------------------------------------------------ the server
+
+
+class Handler(BaseHTTPRequestHandler):
+    model = "z-ai/glm-5.3-flash"
+    key = ""
+    verbose = False
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        """Quiet unless asked. The default handler writes a line per request to stderr."""
+
+        if self.verbose:
+            sys.stderr.write((format % args if args else format) + "\n")
+
+    def _fail(self, status: int, message: str) -> None:
+        body = json.dumps({"type": "error", "error": {"type": "api_error", "message": message}})
+        raw = body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _health(self) -> None:
+        """Claude Code probes `/api/hello` before it starts. A 501 there is noise in the log."""
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", "2")
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(b"{}")
+
+    def do_HEAD(self) -> None:  # noqa: N802
+        self._health()
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._health()
+
+    def do_POST(self) -> None:  # noqa: N802
+        if not self.path.startswith("/v1/messages"):
+            self._fail(404, f"no route for {self.path}")
+            return
+
+        length = int(self.headers.get("Content-Length") or 0)
+        try:
+            payload = json.loads(self.rfile.read(length) or b"{}")
+        except json.JSONDecodeError as exc:
+            self._fail(400, f"unparseable request: {exc}")
+            return
+
+        upstream = to_openai(payload, self.model)
+        if self.verbose:
+            sys.stderr.write(
+                f"-> {len(upstream['messages'])} messages, {len(upstream.get('tools', []))} tools\n"
+            )
+
+        try:
+            request = urllib.request.Request(  # noqa: S310
+                UPSTREAM,
+                data=json.dumps(upstream).encode("utf-8"),
+                headers={
+                    "Authorization": f"Bearer {self.key}",
+                    "Content-Type": "application/json",
+                    "HTTP-Referer": "https://github.com/fl-sean03/OpenSDL",
+                    "X-Title": "OpenSDL bridge",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=600) as response:  # noqa: S310
+                completion = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:600]
+            self._fail(exc.code if 400 <= exc.code < 600 else 502, f"openrouter: {detail}")
+            return
+        except Exception as exc:  # noqa: BLE001
+            self._fail(502, f"openrouter unreachable: {exc}")
+            return
+
+        choices = completion.get("choices") or []
+        if not choices:
+            self._fail(502, f"openrouter returned no choices: {json.dumps(completion)[:300]}")
+            return
+
+        choice = choices[0]
+        blocks = to_anthropic_blocks(choice.get("message") or {})
+        stop = STOP_REASONS.get(choice.get("finish_reason") or "stop", "end_turn")
+        if any(b["type"] == "tool_use" for b in blocks):
+            stop = "tool_use"
+        usage = completion.get("usage") or {}
+
+        if payload.get("stream"):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "keep-alive")
+            self.send_header("Transfer-Encoding", "chunked")
+            self.end_headers()
+            for chunk in sse_events(blocks, stop, usage, self.model):
+                raw = chunk.encode("utf-8")
+                self.wfile.write(f"{len(raw):X}\r\n".encode())
+                self.wfile.write(raw)
+                self.wfile.write(b"\r\n")
+            self.wfile.write(b"0\r\n\r\n")
+            self.wfile.flush()
+            return
+
+        body = json.dumps(
+            {
+                "id": f"msg_{uuid.uuid4().hex[:24]}",
+                "type": "message",
+                "role": "assistant",
+                "model": self.model,
+                "content": blocks,
+                "stop_reason": stop,
+                "stop_sequence": None,
+                "usage": {
+                    "input_tokens": int(usage.get("prompt_tokens", 0)),
+                    "output_tokens": int(usage.get("completion_tokens", 0)),
+                },
+            }
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="z-ai/glm-5.3-flash")
+    parser.add_argument("--port", type=int, default=8899)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    key = os.environ.get("OPENROUTER_API_KEY", "")
+    if not key:
+        from pathlib import Path
+
+        candidate = Path.home() / ".secrets" / "openrouter"
+        if candidate.is_file():
+            key = candidate.read_text(encoding="utf-8").strip()
+    if not key:
+        sys.stderr.write(
+            "no OpenRouter key. Set OPENROUTER_API_KEY or write it to ~/.secrets/openrouter.\n"
+        )
+        return 2
+
+    Handler.model = args.model
+    Handler.key = key
+    Handler.verbose = args.verbose
+
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    sys.stderr.write(
+        f"bridging {args.model} on http://{args.host}:{args.port}\n"
+        f"  ANTHROPIC_BASE_URL=http://{args.host}:{args.port} ANTHROPIC_API_KEY=unused claude ...\n"
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scene_agent/client.py
+++ b/scripts/scene_agent/client.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -90,6 +91,47 @@ def image_part(path: Path) -> dict[str, object]:
     }
 
 
+class NoContent(RuntimeError):
+    """The model spent its budget reasoning and said nothing. Usually worth another attempt."""
+
+
+def ask_retrying(
+    messages: list[dict[str, object]],
+    *,
+    attempts: int = 3,
+    max_tokens: int = 12000,
+    model: str = DEFAULT_MODEL,
+    key: str | None = None,
+    temperature: float = 0.2,
+) -> Reply:
+    """`ask`, but a model that says nothing gets asked again with more room to answer.
+
+    An empty reply killed a whole five-stage build once: the exception escaped the per-stage retry
+    loop, so one transient failure at stage three threw away two stages that had already passed.
+    Transport trouble belongs to the caller of the model, not to the thing being built.
+
+    Each attempt raises the budget, since the failure mode is a reasoning trace that ran long.
+    """
+    budget = max_tokens
+    last: Exception | None = None
+    for attempt in range(attempts):
+        try:
+            return ask(
+                messages,
+                model=model,
+                key=key,
+                temperature=temperature,
+                max_tokens=budget,
+            )
+        except NoContent as exc:
+            last = exc
+            budget = int(budget * 1.6)
+        except RuntimeError as exc:
+            last = exc
+            time.sleep(2.0 * (attempt + 1))
+    raise last if last is not None else RuntimeError("no attempt was made")
+
+
 def ask(
     messages: list[dict[str, object]],
     *,
@@ -142,7 +184,7 @@ def ask(
         # looks like a silent empty reply unless it is named.
         reason = choices[0].get("finish_reason")
         thought = (message.get("reasoning") or "")[:300]
-        raise RuntimeError(
+        raise NoContent(
             f"the model returned no content (finish_reason={reason!r}). This usually means "
             f"max_tokens was spent on reasoning before any answer began. Reasoning began: "
             f"{thought!r}"

--- a/scripts/scene_agent/client.py
+++ b/scripts/scene_agent/client.py
@@ -25,6 +25,14 @@ ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"
 #: and a real decision at a frontier model's.
 DEFAULT_MODEL = "z-ai/glm-5.3-flash"
 
+#: GLM 5.3 Flash does not stop reasoning on its own. Left alone it spends the whole completion
+#: budget thinking and returns `finish_reason="length"` with zero content, which reads as the model
+#: having nothing to say. Measured on one Blender brief: plain, 143s and 6000 tokens of reasoning
+#: for 0 bytes of answer; with this flag, 34s and 2181 bytes. It still reasons — the flag excludes
+#: the trace from the response — but it now yields an answer. `{"enabled": false}` is rejected by
+#: the provider outright.
+REASONING = {"exclude": True}
+
 
 class MissingCredential(RuntimeError):
     """Raised when no key is configured, with the two ways to supply one."""
@@ -81,7 +89,7 @@ def ask(
     model: str = DEFAULT_MODEL,
     key: str | None = None,
     temperature: float = 0.2,
-    max_tokens: int = 32000,
+    max_tokens: int = 12000,
     timeout: float = 240.0,
 ) -> Reply:
     """One completion. Raises on transport failure so the caller decides whether to retry."""
@@ -92,6 +100,7 @@ def ask(
             "messages": messages,
             "temperature": temperature,
             "max_tokens": max_tokens,
+            "reasoning": REASONING,
         }
     ).encode("utf-8")
 

--- a/scripts/scene_agent/client.py
+++ b/scripts/scene_agent/client.py
@@ -25,6 +25,13 @@ ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"
 #: and a real decision at a frontier model's.
 DEFAULT_MODEL = "z-ai/glm-5.3-flash"
 
+#: Two models, because the two jobs need different things. Writing a scene needs no eyes, and
+#: GLM 4.6 does it reliably in 17-116s on every brief measured. Judging a render needs eyes, and
+#: GLM 5.3 Flash is the cheap model that has them. Measured on the same base brief, 4.6 answered
+#: four prompt variants out of four; 5.3 Flash exhausted its budget on all of them.
+GENERATOR_MODEL = "z-ai/glm-4.6"
+CRITIC_MODEL = "z-ai/glm-5.3-flash"
+
 #: GLM 5.3 Flash does not stop reasoning on its own. Left alone it spends the whole completion
 #: budget thinking and returns `finish_reason="length"` with zero content, which reads as the model
 #: having nothing to say. Measured on one Blender brief: plain, 143s and 6000 tokens of reasoning

--- a/scripts/scene_agent/client.py
+++ b/scripts/scene_agent/client.py
@@ -81,7 +81,7 @@ def ask(
     model: str = DEFAULT_MODEL,
     key: str | None = None,
     temperature: float = 0.2,
-    max_tokens: int = 16000,
+    max_tokens: int = 32000,
     timeout: float = 240.0,
 ) -> Reply:
     """One completion. Raises on transport failure so the caller decides whether to retry."""
@@ -118,8 +118,21 @@ def ask(
     if not choices:
         raise RuntimeError(f"OpenRouter returned no choices: {json.dumps(payload)[:400]}")
     usage = payload.get("usage") or {}
+    message = choices[0].get("message") or {}
+    text = message.get("content")
+    if not text:
+        # GLM 5.3 Flash reasons before it answers, and reasoning is billed as completion tokens.
+        # An exhausted budget therefore returns content=None with a full reasoning trace, which
+        # looks like a silent empty reply unless it is named.
+        reason = choices[0].get("finish_reason")
+        thought = (message.get("reasoning") or "")[:300]
+        raise RuntimeError(
+            f"the model returned no content (finish_reason={reason!r}). This usually means "
+            f"max_tokens was spent on reasoning before any answer began. Reasoning began: "
+            f"{thought!r}"
+        )
     return Reply(
-        text=choices[0].get("message", {}).get("content", ""),
+        text=text,
         prompt_tokens=int(usage.get("prompt_tokens", 0)),
         completion_tokens=int(usage.get("completion_tokens", 0)),
     )

--- a/scripts/scene_agent/client.py
+++ b/scripts/scene_agent/client.py
@@ -1,0 +1,149 @@
+"""A small OpenRouter client for the scene agent.
+
+Deliberately not a framework dependency. This is a tool that produces twin assets, so it lives in
+`scripts/` and talks to one endpoint with `urllib`. Nothing here imports an OpenSDL package and
+nothing in OpenSDL imports this.
+
+The model this was built for is `z-ai/glm-5.3-flash`, chosen because it accepts images. A render
+loop whose critic cannot see the render is a loop that argues with itself about text.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"
+
+#: 1.3M context, accepts text, image and video, and costs $0.075/$0.25 per million tokens. The
+#: cheapness matters: an iterative loop that reruns twenty times is a rounding error at this price
+#: and a real decision at a frontier model's.
+DEFAULT_MODEL = "z-ai/glm-5.3-flash"
+
+
+class MissingCredential(RuntimeError):
+    """Raised when no key is configured, with the two ways to supply one."""
+
+
+@dataclass(frozen=True)
+class Reply:
+    text: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+    @property
+    def cost_usd(self) -> float:
+        """What this exchange cost, at the published GLM 5.3 Flash rates."""
+
+        return self.prompt_tokens * 0.075e-6 + self.completion_tokens * 0.25e-6
+
+
+def api_key(explicit: str | None = None) -> str:
+    """The key, from the argument, the environment, or a file, in that order."""
+
+    if explicit:
+        return explicit
+    from_env = os.environ.get("OPENROUTER_API_KEY")
+    if from_env:
+        return from_env
+    for candidate in (
+        Path.home() / ".secrets" / "openrouter",
+        Path.home() / ".config" / "openrouter" / "key",
+    ):
+        if candidate.is_file():
+            content = candidate.read_text(encoding="utf-8").strip()
+            if content:
+                return content
+    raise MissingCredential(
+        "no OpenRouter key. Set OPENROUTER_API_KEY, or write the key to ~/.secrets/openrouter. "
+        "Get one at https://openrouter.ai/keys."
+    )
+
+
+def image_part(path: Path) -> dict[str, object]:
+    """One image, inlined as a data URL, in the shape the chat API expects."""
+
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    return {
+        "type": "image_url",
+        "image_url": {"url": f"data:image/png;base64,{encoded}"},
+    }
+
+
+def ask(
+    messages: list[dict[str, object]],
+    *,
+    model: str = DEFAULT_MODEL,
+    key: str | None = None,
+    temperature: float = 0.2,
+    max_tokens: int = 16000,
+    timeout: float = 240.0,
+) -> Reply:
+    """One completion. Raises on transport failure so the caller decides whether to retry."""
+
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+    ).encode("utf-8")
+
+    request = urllib.request.Request(  # noqa: S310
+        ENDPOINT,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {api_key(key)}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/fl-sean03/OpenSDL",
+            "X-Title": "OpenSDL scene agent",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:500]
+        raise RuntimeError(f"OpenRouter returned {exc.code}: {detail}") from exc
+
+    choices = payload.get("choices") or []
+    if not choices:
+        raise RuntimeError(f"OpenRouter returned no choices: {json.dumps(payload)[:400]}")
+    usage = payload.get("usage") or {}
+    return Reply(
+        text=choices[0].get("message", {}).get("content", ""),
+        prompt_tokens=int(usage.get("prompt_tokens", 0)),
+        completion_tokens=int(usage.get("completion_tokens", 0)),
+    )
+
+
+def fenced_python(text: str) -> str:
+    """The largest Python block in a reply, or the whole reply if it is bare code.
+
+    Models fence inconsistently and sometimes explain first. Taking the largest block rather than
+    the first avoids picking up a two-line illustration in the preamble.
+    """
+
+    blocks: list[str] = []
+    marker = "```"
+    parts = text.split(marker)
+    for index in range(1, len(parts), 2):
+        block = parts[index]
+        first_newline = block.find("\n")
+        if first_newline == -1:
+            continue
+        language = block[:first_newline].strip().lower()
+        code = block[first_newline + 1 :]
+        if language in {"", "python", "py"}:
+            blocks.append(code)
+    if blocks:
+        return max(blocks, key=len).strip()
+    return text.strip()

--- a/scripts/scene_agent/export.py
+++ b/scripts/scene_agent/export.py
@@ -1,0 +1,161 @@
+"""Turn a generated scene into something OpenSDL can bind to.
+
+A render is a picture. A twin is a picture with names an adapter can address: `twin.yaml` maps a
+semantic entity to a scene node, so when a capability moves the gripper, the projector knows which
+node to move. Without that mapping a beautiful scene is decoration.
+
+This is the step that carries forward. Whatever domain D6 lands on, the facility-scale scene has to
+arrive as GLB plus a digest plus an entity mapping, exactly as
+`examples/digital-twin-surrogate/twin.yaml` does today. Proving it on a bench with two instruments
+is cheap; discovering it does not work at facility scale is not.
+
+The generated `twin.yaml` is a DRAFT. It names every body the scene declared and guesses which are
+worth binding, and a human decides what is actually a resource. Guessing the mapping and presenting
+it as authoritative would be the wrong kind of helpful.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from .prelude import PRELUDE
+from .render import blender_executable
+
+#: Appended after the scene script. Exports the GLB and reports the node inventory.
+EXPORT = """
+# ---- appended by scripts/scene_agent/export.py ----
+import json as _json
+import bpy as _bpy
+import mathutils as _mathutils
+
+_bpy.context.view_layer.update()
+
+_inventory = []
+for _obj in _bpy.data.objects:
+    if _obj.type != "MESH":
+        continue
+    _pts = [_obj.matrix_world @ _mathutils.Vector(_c) for _c in _obj.bound_box]
+    _inventory.append(
+        {{
+            "node": _obj.name,
+            "location": [round(_v, 5) for _v in _obj.location],
+            "dimensions": [round(_v, 5) for _v in _obj.dimensions],
+            "centre": [
+                round(sum(_p[_i] for _p in _pts) / len(_pts), 5) for _i in range(3)
+            ],
+            "top": round(max(_p.z for _p in _pts), 5),
+        }}
+    )
+
+_bpy.ops.export_scene.gltf(
+    filepath={GLB_PATH!r},
+    export_format="GLB",
+    use_selection=False,
+    export_apply=True,
+)
+
+print("<<<OPENSDL-EXPORT")
+print(_json.dumps({{"nodes": _inventory}}))
+print("OPENSDL-EXPORT>>>")
+"""
+
+
+@dataclass(frozen=True)
+class Export:
+    glb: Path
+    digest: str
+    nodes: list[dict[str, object]]
+    twin: Path
+
+
+#: A body worth binding is one a capability could plausibly act on. Everything else is set
+#: dressing, and listing the floor as a resource would make the draft worse than useless.
+SCENERY = ("floor", "backdrop", "wall", "ground")
+
+
+def _looks_bindable(node: dict[str, object]) -> bool:
+    name = str(node.get("node", "")).lower()
+    if any(word in name for word in SCENERY):
+        return False
+    dims = node.get("dimensions")
+    return not (isinstance(dims, list) and dims and max(float(d) for d in dims) > 5.0)
+
+
+def export_scene(
+    source: str,
+    out_dir: Path,
+    *,
+    blender: str | None = None,
+    revision: str = "generated",
+    timeout: float = 420.0,
+) -> Export:
+    """Render the script to a GLB, digest it, and write a draft twin definition beside it."""
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    glb = out_dir / "scene.glb"
+    script = PRELUDE + "\n" + source + "\n" + EXPORT.format(GLB_PATH=str(glb))
+
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, encoding="utf-8") as handle:
+        handle.write(script)
+        path = Path(handle.name)
+    try:
+        done = subprocess.run(  # noqa: S603
+            [blender_executable(blender), "-b", "-P", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    finally:
+        path.unlink(missing_ok=True)
+
+    if "<<<OPENSDL-EXPORT" not in done.stdout:
+        tail = "\n".join(done.stderr.strip().splitlines()[-20:])
+        raise RuntimeError(f"the scene did not export:\n{tail}")
+    body = done.stdout.split("<<<OPENSDL-EXPORT", 1)[1].split("OPENSDL-EXPORT>>>", 1)[0]
+    nodes = json.loads(body.strip()).get("nodes", [])
+
+    if not glb.is_file():
+        raise RuntimeError("blender reported an export but wrote no GLB")
+    digest = hashlib.sha256(glb.read_bytes()).hexdigest()
+
+    bindable = [n for n in nodes if _looks_bindable(n)]
+    lines = [
+        "apiVersion: opensdl.dev/v0alpha1",
+        "kind: DigitalTwin",
+        "version: 0.1.0",
+        f"revision: {revision}",
+        "coordinateFrame:",
+        "  unit: m",
+        "  handedness: right",
+        "  upAxis: Z",
+        "  origin: [0.0, 0.0, 0.0]",
+        "scene:",
+        f"  path: {glb.name}",
+        f"  sha256: {digest}",
+        "# DRAFT. Every body the scene declared is listed below. Which of these are resources,",
+        "# and what they are called in the manifest, is a decision for whoever owns the laboratory.",
+        "entities:",
+    ]
+    for node in bindable:
+        name = str(node["node"])
+        lines.append(f"  - id: {name.lower().replace('_', '-')}")
+        lines.append(f"    node: {name}")
+        lines.append("    resources: []")
+    lines.append("anchors:")
+    for node in bindable:
+        centre = node.get("centre") or [0, 0, 0]
+        top = node.get("top", 0)
+        name = str(node["node"])
+        lines.append(f"  - id: {name.lower().replace('_', '-')}-top")
+        lines.append(f"    node: {name}")
+        lines.append(f"    position: [{centre[0]}, {centre[1]}, {top}]")
+
+    twin = out_dir / "twin.yaml"
+    twin.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return Export(glb=glb, digest=digest, nodes=nodes, twin=twin)

--- a/scripts/scene_agent/export.py
+++ b/scripts/scene_agent/export.py
@@ -75,7 +75,10 @@ class Export:
 
 #: A body worth binding is one a capability could plausibly act on. Everything else is set
 #: dressing, and listing the floor as a resource would make the draft worse than useless.
-SCENERY = ("floor", "backdrop", "wall", "ground")
+#: `shell_` is the prefix `room()` puts on the floor, ceiling, walls, mullions and the lit card
+#: outside the glazing. A mullion is small enough to pass the size cut below, so the prefix is what
+#: keeps a window frame out of a list of things a capability can address.
+SCENERY = ("floor", "backdrop", "wall", "ground", "shell_", "lane_", "fixture", "tray_", "duct")
 
 
 def _looks_bindable(node: dict[str, object]) -> bool:

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -42,7 +42,27 @@ Rules that are not negotiable:
 - Prefer real dimensions in metres. A bench is about 0.9 m tall, a microplate is 127.76 x 85.48 mm.
 
 You are judged on what the render looks like, so composition, materials and lighting are part of the
-job, not decoration."""
+job, not decoration.
+
+Blender 5.2 specifics that have already cost attempts, so get them right first time:
+
+- `read_factory_settings(use_empty=True)` leaves `scene.world` as **None**. Create one before
+  touching it: `scene.world = bpy.data.worlds.new("World")`.
+- **Aim the camera by tracking, never by guessing Euler angles.** Guessed rotations are the single
+  most common way to render a picture of the floor. Do this:
+
+      import mathutils
+      direction = target_location - cam.location
+      cam.rotation_euler = direction.to_track_quat('-Z', 'Y').to_euler()
+
+  where `target_location` is a `mathutils.Vector` at the middle of what you want in shot. Then
+  check the framing is plausible: the camera must be above the subject and far enough back that the
+  whole thing fits.
+- `Material.use_nodes = True` warns as deprecated. Materials already have nodes; set
+  `mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value` directly.
+- `bpy.ops.mesh.primitive_*_add` operates on the active collection and sets the active object. For
+  anything beyond a couple of bodies prefer `bpy.data.meshes.new` plus `bpy.data.objects.new` plus
+  `collection.objects.link`, which does not depend on operator context."""
 
 CRITIC_SYSTEM = """You judge a rendered Blender scene against a brief, and you are hard to please.
 

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -70,6 +70,14 @@ import bpy primitives to do what they do — each exists because hand-rolling it
     box(name, (x,y,z), location, material_)      box of that size in metres, centred on location
     cylinder(name, radius, depth, location, m)   upright cylinder
     plane(name, size, location, material_)       flat square
+    room(width, depth, height, floor_material,   an INTERIOR: floor, ceiling, walls, one side
+         wall_material, ceiling_material,        left open for the camera. Bodies are named
+         open_side="front")                      Shell_* so the checks know they are the room
+    interior_view(target, stand, lens=24.0)      a camera INSIDE a room at eye height, wide.
+                                                 Do not call frame_all after it
+    interior_lighting(shell, rows, cols)         ceiling panels INSIDE the room. A three-point
+                                                 rig stands its lights outside the walls and the
+                                                 room comes out black
     studio(material_)                            floor plus backdrop, sized so no edge or horizon
                                                  enters frame. USE THIS instead of a bare floor
                                                  plane: a 10 m floor shows its far edge as a hard

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -77,7 +77,13 @@ import bpy primitives to do what they do — each exists because hand-rolling it
     top_of(obj)                                  height of an object's upper face
     aim(obj, target)                             point an object's -Z at a point
     camera(location, target, lens=42.0)          camera looking at target, set as scene camera
-    frame_all(cam)                               pull the camera back until everything fits
+    frame_all(cam)                               move the camera until everything fits
+    frame_all(cam, distance=3.2)                 STAY at that range and solve for the lens
+                                                 instead. Use this when the brief gives a
+                                                 distance. Do NOT change `lens` to control
+                                                 framing: a longer lens is narrower and needs
+                                                 MORE room, which is the opposite of what it
+                                                 looks like
     area_light(name, location, target, energy,   area light aimed at a point
                size, color)
 

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -1,0 +1,270 @@
+"""The iterate-until-it-looks-right loop.
+
+One pass is: write a Blender script, render it headlessly, look at the render, say what is wrong,
+rewrite. The loop ends when the critic scores the image at or above the bar, or when the attempts
+run out.
+
+Two things make this more than a chat transcript.
+
+The critic sees the render **and** the structured probe report from the same attempt. Those two
+channels fail differently and neither subsumes the other: an image cannot show a mesh with no faces
+or a non-finite transform, and a report cannot show that the camera is pointing at the back of the
+instrument. `examples/digital-twin-surrogate/scene/check_scene.py` records the same finding from the
+other direction, which is why both are always in the prompt.
+
+And every attempt is kept — script, render, critique, cost. The run directory is the artifact. A
+loop whose intermediate states are thrown away cannot be debugged, and cannot show anybody how the
+scene got where it got.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from .client import DEFAULT_MODEL, Reply, ask, fenced_python, image_part
+from .render import RenderOutcome, render_script
+
+SYSTEM = """You author Blender 5.2 Python scripts that build a scene from nothing.
+
+Rules that are not negotiable:
+- Emit ONE fenced ```python block and nothing else. No commentary outside it.
+- Start from `bpy.ops.wm.read_factory_settings(use_empty=True)`. The scene begins empty.
+- Build geometry procedurally. You have no asset library, no external files, no network.
+- Create a camera, set `bpy.context.scene.camera`, and light the scene. A render with no camera or
+  no light is a black rectangle and scores zero.
+- Do NOT set `scene.render.filepath`, resolution, engine, or call `bpy.ops.render.render`. The
+  harness appends all of that. Setting it yourself will be overwritten.
+- Blender 5.2's render engines are BLENDER_EEVEE, BLENDER_WORKBENCH and CYCLES. BLENDER_EEVEE_NEXT
+  does not exist here.
+- Prefer real dimensions in metres. A bench is about 0.9 m tall, a microplate is 127.76 x 85.48 mm.
+
+You are judged on what the render looks like, so composition, materials and lighting are part of the
+job, not decoration."""
+
+CRITIC_SYSTEM = """You judge a rendered Blender scene against a brief, and you are hard to please.
+
+Reply with ONE fenced ```json block:
+{"score": 0-100, "verdict": "...", "defects": ["..."], "next_actions": ["..."]}
+
+`score` is how well the render satisfies the brief: 0 is unusable, 60 is recognisable but crude, 80
+is a credible technical illustration, 95 is publishable.
+`defects` names what is actually wrong, each one specific enough to fix. "improve the lighting" is
+useless. "the key light is behind the camera so every surface is flat and the form reads as a
+silhouette" is useful.
+`next_actions` are concrete script-level changes, in priority order, at most five.
+
+You will be given the render AND a structured report of the scene graph. Use both. If the report
+shows a defect the image cannot reveal, say so. If the image shows a problem the report cannot see,
+say that too."""
+
+
+@dataclass
+class Attempt:
+    """One pass through the loop, kept whole so the run can be replayed and shown."""
+
+    index: int
+    script: str
+    ok: bool
+    score: int | None = None
+    verdict: str = ""
+    defects: list[str] = field(default_factory=list)
+    next_actions: list[str] = field(default_factory=list)
+    probe_defects: list[str] = field(default_factory=list)
+    stderr: str = ""
+    image: str | None = None
+    cost_usd: float = 0.0
+
+
+def _json_block(text: str) -> dict[str, object]:
+    """The first JSON object in a reply, fenced or bare."""
+
+    fenced = re.search(r"```(?:json)?\s*\n(.*?)```", text, re.DOTALL)
+    body = fenced.group(1) if fenced else text
+    start, end = body.find("{"), body.rfind("}")
+    if start == -1 or end <= start:
+        return {}
+    try:
+        parsed = json.loads(body[start : end + 1])
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _strings(value: object) -> list[str]:
+    """A model may return a string, a list, or nothing where a list was asked for."""
+
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, str) and value.strip():
+        return [value]
+    return []
+
+
+def _report_digest(outcome: RenderOutcome) -> str:
+    """The probe report, trimmed to what a critic can act on."""
+
+    report = dict(outcome.report)
+    objects = report.get("objects")
+    if isinstance(objects, list) and len(objects) > 40:
+        report["objects"] = objects[:40]
+        report["objects_truncated"] = f"{len(objects) - 40} more not shown"
+    return json.dumps(report, indent=1)[:6000]
+
+
+def generate(brief: str, *, model: str, key: str | None) -> tuple[str, Reply]:
+    """First attempt, from the brief alone."""
+
+    reply = ask(
+        [
+            {"role": "system", "content": SYSTEM},
+            {"role": "user", "content": f"Build this scene.\n\n{brief}"},
+        ],
+        model=model,
+        key=key,
+    )
+    return fenced_python(reply.text), reply
+
+
+def critique(
+    brief: str, outcome: RenderOutcome, *, model: str, key: str | None
+) -> tuple[dict[str, object], Reply]:
+    """Judge one render, with the image and the scene report both in the prompt."""
+
+    content: list[dict[str, object]] = [
+        {
+            "type": "text",
+            "text": (
+                f"BRIEF\n{brief}\n\nSCENE REPORT\n{_report_digest(outcome)}\n\n"
+                "Judge the attached render against the brief."
+            ),
+        }
+    ]
+    if outcome.image is not None:
+        content.append(image_part(outcome.image))
+    else:
+        content[0]["text"] = str(content[0]["text"]) + (
+            f"\n\nNOTHING RENDERED. Blender said:\n{outcome.stderr[:2000]}\n"
+            "Score this 0 and make next_actions the fix."
+        )
+
+    reply = ask(
+        [
+            {"role": "system", "content": CRITIC_SYSTEM},
+            {"role": "user", "content": content},
+        ],
+        model=model,
+        key=key,
+    )
+    return _json_block(reply.text), reply
+
+
+def refine(
+    brief: str,
+    script: str,
+    judgement: dict[str, object],
+    outcome: RenderOutcome,
+    *,
+    model: str,
+    key: str | None,
+) -> tuple[str, Reply]:
+    """Rewrite the script to answer the critique. The whole script comes back, never a patch."""
+
+    defects = _strings(judgement.get("defects"))
+    actions = _strings(judgement.get("next_actions"))
+    instruction = (
+        f"BRIEF\n{brief}\n\n"
+        f"YOUR PREVIOUS SCRIPT\n```python\n{script}\n```\n\n"
+        f"WHAT IS WRONG\n{json.dumps(defects, indent=1)}\n\n"
+        f"WHAT TO DO\n{json.dumps(actions, indent=1)}\n\n"
+        f"SCENE REPORT FROM THAT ATTEMPT\n{_report_digest(outcome)}\n\n"
+        "Return the COMPLETE corrected script in one fenced python block. Keep what worked."
+    )
+    if outcome.stderr:
+        instruction += f"\n\nBLENDER STDERR\n{outcome.stderr[:1500]}"
+
+    reply = ask(
+        [{"role": "system", "content": SYSTEM}, {"role": "user", "content": instruction}],
+        model=model,
+        key=key,
+    )
+    return fenced_python(reply.text), reply
+
+
+def run(
+    brief: str,
+    out_dir: Path,
+    *,
+    iterations: int = 6,
+    target_score: int = 85,
+    model: str = DEFAULT_MODEL,
+    key: str | None = None,
+    blender: str | None = None,
+    width: int = 960,
+    height: int = 540,
+    engine: str = "BLENDER_EEVEE",
+    samples: int = 64,
+    on_step: object = None,
+) -> list[Attempt]:
+    """Drive the loop and leave every attempt on disk. Returns the attempts in order."""
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "brief.md").write_text(brief, encoding="utf-8")
+
+    attempts: list[Attempt] = []
+    script, reply = generate(brief, model=model, key=key)
+    spent = reply.cost_usd
+
+    for index in range(1, iterations + 1):
+        step_dir = out_dir / f"{index:02d}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+        (step_dir / "scene.py").write_text(script, encoding="utf-8")
+
+        outcome = render_script(
+            script,
+            step_dir,
+            blender=blender,
+            width=width,
+            height=height,
+            engine=engine,
+            samples=samples,
+        )
+        judgement, critic_reply = critique(brief, outcome, model=model, key=key)
+        spent += critic_reply.cost_usd
+
+        raw_score = judgement.get("score")
+        attempt = Attempt(
+            index=index,
+            script=script,
+            ok=outcome.ok,
+            score=int(raw_score) if isinstance(raw_score, (int, float)) else None,
+            verdict=str(judgement.get("verdict", "")),
+            defects=_strings(judgement.get("defects")),
+            next_actions=_strings(judgement.get("next_actions")),
+            probe_defects=outcome.defects,
+            stderr=outcome.stderr,
+            image=str(outcome.image) if outcome.image else None,
+            cost_usd=spent,
+        )
+        attempts.append(attempt)
+        (step_dir / "critique.json").write_text(
+            json.dumps(asdict(attempt) | {"script": "see scene.py"}, indent=2), encoding="utf-8"
+        )
+        if callable(on_step):
+            on_step(attempt)
+
+        if attempt.score is not None and attempt.score >= target_score:
+            break
+        if index == iterations:
+            break
+
+        script, refine_reply = refine(brief, script, judgement, outcome, model=model, key=key)
+        spent += refine_reply.cost_usd
+
+    (out_dir / "run.json").write_text(
+        json.dumps([asdict(a) | {"script": f"{a.index:02d}/scene.py"} for a in attempts], indent=2),
+        encoding="utf-8",
+    )
+    return attempts

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -24,7 +24,14 @@ import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
-from .client import CRITIC_MODEL, GENERATOR_MODEL, Reply, ask, fenced_python, image_part
+from .client import (
+    CRITIC_MODEL,
+    GENERATOR_MODEL,
+    Reply,
+    ask_retrying,
+    fenced_python,
+    image_part,
+)
 from .render import RenderOutcome, render_script
 
 SYSTEM = """You author Blender 5.2 Python scripts that build a scene from nothing.
@@ -194,7 +201,7 @@ def generate(
 ) -> tuple[str, Reply]:
     """First attempt, from the brief alone."""
 
-    reply = ask(
+    reply = ask_retrying(
         [
             {"role": "system", "content": SYSTEM},
             {"role": "user", "content": f"Build this scene.\n\n{brief}"},
@@ -227,7 +234,7 @@ def critique(
             "Score this 0 and make next_actions the fix."
         )
 
-    reply = ask(
+    reply = ask_retrying(
         [
             {"role": "system", "content": CRITIC_SYSTEM},
             {"role": "user", "content": content},
@@ -262,7 +269,7 @@ def refine(
     if outcome.stderr:
         instruction += f"\n\nBLENDER STDERR\n{outcome.stderr[:1500]}"
 
-    reply = ask(
+    reply = ask_retrying(
         [{"role": "system", "content": SYSTEM}, {"role": "user", "content": instruction}],
         model=model,
         key=key,

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -44,42 +44,35 @@ Rules that are not negotiable:
 You are judged on what the render looks like, so composition, materials and lighting are part of the
 job, not decoration.
 
-Blender 5.2 specifics that have already cost attempts, so get them right first time:
+These helpers are ALREADY DEFINED above your script. Use them. Do not redefine them, and do not
+import bpy primitives to do what they do — each exists because hand-rolling it has failed before.
 
-- `read_factory_settings(use_empty=True)` leaves `scene.world` as **None**. Create one before
-  touching it: `scene.world = bpy.data.worlds.new("World")`.
-- **Aim the camera by tracking, never by guessing Euler angles.** Guessed rotations are the single
-  most common way to render a picture of the floor. Do this:
+    new_scene()                                  empty scene WITH a world, returns the scene
+    ambient(strength=0.1, color=(r,g,b))         world light; keep strength 0.05-0.2
+    material(name, color, roughness, metallic)   Principled material
+    box(name, (x,y,z), location, material_)      box of that size in metres, centred on location
+    cylinder(name, radius, depth, location, m)   upright cylinder
+    plane(name, size, location, material_)       flat square, for floors
+    aim(obj, target)                             point an object's -Z at a point
+    camera(location, target, lens=42.0)          camera looking at target, set as scene camera
+    area_light(name, location, target, energy,   area light aimed at a point
+               size, color)
 
-      import mathutils
-      direction = target_location - cam.location
-      cam.rotation_euler = direction.to_track_quat('-Z', 'Y').to_euler()
+Start with `scene = new_scene()`. Build bodies with `box`, `cylinder` and `plane`. Frame with
+`camera(...)`, which aims correctly — never write rotation_euler by hand. Light with `area_light`.
 
-  where `target_location` is a `mathutils.Vector` at the middle of what you want in shot. Then
-  check the framing is plausible: the camera must be above the subject and far enough back that the
-  whole thing fits.
-- `Material.use_nodes = True` warns as deprecated. Materials already have nodes; set
-  `mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value` directly.
-- `bpy.ops.mesh.primitive_*_add` operates on the active collection and sets the active object. For
-  anything beyond a couple of bodies prefer `bpy.data.meshes.new` plus `bpy.data.objects.new` plus
-  `collection.objects.link`, which does not depend on operator context.
-- `bmesh.ops.create_cylinder` **does not exist**. Use `bmesh.ops.create_cone` with `radius1` equal
-  to `radius2`. The available primitives are `create_cube`, `create_cone`, `create_uvsphere`,
-  `create_icosphere`, `create_grid` and `create_circle`.
+**Lighting numbers, because these renders keep blowing out.** The harness renders with the Standard
+view transform, so there is no filmic roll-off to hide an overexposed scene. A measured failure: an
+800 W key at 2.8 m over 0.2-albedo surfaces put 48% of the frame at pure white.
 
-**Lighting, which is where these renders keep failing.** The harness renders with the Standard view
-transform, so there is no filmic roll-off to hide an overexposed scene: what you light is what you
-get. A measured example — an 800 W key at 2.8 m over a bench of 0.2-albedo surfaces blew 48% of the
-frame to pure white.
+    key   area_light(..., energy=80-150,  size=1.0-1.5)
+    fill  area_light(..., energy=20-40,   size=1.0, cooler colour, opposite side)
+    world ambient(strength=0.05-0.2)
 
-Sane starting points for a bench-scale scene in Cycles, lights 2 to 3 m from the subject:
+Aim for real blacks, real whites, and most of the image between them.
 
-- key area light, 1.0-1.5 m size: **80-150 W**
-- fill area light, opposite side, 1.0 m size: **20-40 W**, and a cooler colour
-- world background strength: **0.05-0.2**
-
-Aim for a picture with real blacks and real whites and most of the image in between. If a surface
-is meant to read as dark grey, it needs both a low albedo and a light that does not overwhelm it."""
+Group each assembly into its own function so the script stays readable as it grows.
+"""
 
 CRITIC_SYSTEM = """You judge a rendered Blender scene against a brief, and you are hard to please.
 

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -64,7 +64,11 @@ import bpy primitives to do what they do — each exists because hand-rolling it
     lab_lighting(target, cam)                    three-point rig placed off the CAMERA axis
     box(name, (x,y,z), location, material_)      box of that size in metres, centred on location
     cylinder(name, radius, depth, location, m)   upright cylinder
-    plane(name, size, location, material_)       flat square, for floors
+    plane(name, size, location, material_)       flat square
+    studio(material_)                            floor plus backdrop, sized so no edge or horizon
+                                                 enters frame. USE THIS instead of a bare floor
+                                                 plane: a 10 m floor shows its far edge as a hard
+                                                 diagonal seam once the camera tilts up
     bench(name, width, depth, top_z=0.90,        a whole bench: top placed by its SURFACE height,
           top_material=, leg_material=)          legs reaching up into it. Use this, do not build
                                                  a bench out of boxes

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -55,11 +55,18 @@ import bpy primitives to do what they do — each exists because hand-rolling it
     plane(name, size, location, material_)       flat square, for floors
     aim(obj, target)                             point an object's -Z at a point
     camera(location, target, lens=42.0)          camera looking at target, set as scene camera
+    frame_all(cam)                               pull the camera back until everything fits
     area_light(name, location, target, energy,   area light aimed at a point
                size, color)
 
 Start with `scene = new_scene()`. Build bodies with `box`, `cylinder` and `plane`. Frame with
-`camera(...)`, which aims correctly — never write rotation_euler by hand. Light with `area_light`.
+`cam = camera(...)` then `frame_all(cam)` as the last thing before lighting: it measures what you
+actually built and pulls back until none of it is cropped. Never write rotation_euler by hand.
+Light with `area_light`.
+
+Where two bodies meet, **sink one a few millimetres into the other**. Surfaces that end at exactly
+the same height and overlap in plan will z-fight into flickering dark squares. A bench leg should
+reach up *into* the bench top, not stop level with its surface.
 
 **Lighting numbers, because these renders keep blowing out.** The harness renders with the Standard
 view transform, so there is no filmic roll-off to hide an overexposed scene. A measured failure: an

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -24,7 +24,7 @@ import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
-from .client import DEFAULT_MODEL, Reply, ask, fenced_python, image_part
+from .client import CRITIC_MODEL, GENERATOR_MODEL, Reply, ask, fenced_python, image_part
 from .render import RenderOutcome, render_script
 
 SYSTEM = """You author Blender 5.2 Python scripts that build a scene from nothing.
@@ -114,7 +114,9 @@ def _report_digest(outcome: RenderOutcome) -> str:
     return json.dumps(report, indent=1)[:6000]
 
 
-def generate(brief: str, *, model: str, key: str | None) -> tuple[str, Reply]:
+def generate(
+    brief: str, *, model: str = GENERATOR_MODEL, key: str | None = None
+) -> tuple[str, Reply]:
     """First attempt, from the brief alone."""
 
     reply = ask(
@@ -129,7 +131,7 @@ def generate(brief: str, *, model: str, key: str | None) -> tuple[str, Reply]:
 
 
 def critique(
-    brief: str, outcome: RenderOutcome, *, model: str, key: str | None
+    brief: str, outcome: RenderOutcome, *, model: str = CRITIC_MODEL, key: str | None = None
 ) -> tuple[dict[str, object], Reply]:
     """Judge one render, with the image and the scene report both in the prompt."""
 
@@ -199,7 +201,8 @@ def run(
     *,
     iterations: int = 6,
     target_score: int = 85,
-    model: str = DEFAULT_MODEL,
+    model: str = GENERATOR_MODEL,
+    critic_model: str = CRITIC_MODEL,
     key: str | None = None,
     blender: str | None = None,
     width: int = 1280,
@@ -231,7 +234,7 @@ def run(
             engine=engine,
             samples=samples,
         )
-        judgement, critic_reply = critique(brief, outcome, model=model, key=key)
+        judgement, critic_reply = critique(brief, outcome, model=critic_model, key=key)
         spent += critic_reply.cost_usd
 
         raw_score = judgement.get("score")

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -77,6 +77,9 @@ import bpy primitives to do what they do — each exists because hand-rolling it
     bench(name, width, depth, top_z=0.90,        a whole bench: top placed by its SURFACE height,
           top_material=, leg_material=)          legs reaching up into it. Use this, do not build
                                                  a bench out of boxes
+    face_detail(name, parent, (x,y,z),           a slot or panel ON A FACE of a body, proud of
+                where="camera", offset=(dx,dz),   it and never coplanar. where= front/back/left/
+                material_)                        right/top, or "camera" to pick the visible one
     on_surface(name, (x,y,z), (cx,cy),           a body standing ON something, sunk 2 mm so it
                surface, material_)                does not z-fight. `surface` is a height OR
                                                  ANOTHER OBJECT, whose top face is measured.
@@ -112,6 +115,11 @@ actually built and pulls back until none of it is cropped. Never write rotation_
 Then `lab_lighting(target, cam)` LAST, after framing, passing the camera it returned. The rig
 places itself relative to the view axis so the light always models the form; lighting chosen in
 world space lands frontally as often as not and the render comes out flat.
+
+**Use `face_detail` for slots, panels and vents.** It puts the feature on a face the camera can
+see, standing slightly proud so it breaks the surface, and offset so it cannot z-fight with the
+body. Pass `where="camera"` and it picks the visible face itself. Building these by hand has failed
+on all three counts.
 
 **A detail placed inside a solid body is invisible.** A slot modelled as its own box, positioned
 within the housing, renders as nothing and the instrument comes out a featureless block. To show a

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -55,6 +55,9 @@ import bpy primitives to do what they do — each exists because hand-rolling it
     box(name, (x,y,z), location, material_)      box of that size in metres, centred on location
     cylinder(name, radius, depth, location, m)   upright cylinder
     plane(name, size, location, material_)       flat square, for floors
+    bench(name, width, depth, top_z=0.90,        a whole bench: top placed by its SURFACE height,
+          top_material=, leg_material=)          legs reaching up into it. Use this, do not build
+                                                 a bench out of boxes
     on_surface(name, (x,y,z), (cx,cy), surf_z,   a body standing ON a surface, sunk 2 mm so it
                material_)                        does not z-fight. USE THIS for anything on the
                                                  bench: it computes the height for you

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -50,6 +50,8 @@ import bpy primitives to do what they do — each exists because hand-rolling it
     new_scene()                                  empty scene WITH a world, returns the scene
     ambient(strength=0.1, color=(r,g,b))         world light; keep strength 0.05-0.2
     material(name, color, roughness, metallic)   Principled material
+    palette()                                    dict of measured preset materials
+    lab_lighting(target)                         calibrated three-point rig
     box(name, (x,y,z), location, material_)      box of that size in metres, centred on location
     cylinder(name, radius, depth, location, m)   upright cylinder
     plane(name, size, location, material_)       flat square, for floors
@@ -72,7 +74,16 @@ the same height and overlap in plan will z-fight into flickering dark squares. A
 reach up *into* the bench top, and every instrument on the bench goes through `on_surface`, which
 handles this and computes the height so you never write `surface_z + height/2` by hand.
 
-**Lighting numbers, because these renders keep blowing out.** The harness renders with the Standard
+**Use the presets. They are measured, and guessed values keep coming out wrong.**
+
+    p = palette()          bench, polymer, steel, aluminium, floor, labware, glass
+    lab_lighting(target)   the whole three-point rig, exposed correctly
+
+A swatch ramp was rendered to calibrate these. The finding worth knowing: the FLOOR dominates. At
+0.55 albedo it bounces so much light that even a 0.03 surface reads mid-grey and nothing can look
+dark. `p['floor']` is 0.30 for that reason. Do not brighten it.
+
+**Lighting numbers, if you override the rig.** The harness renders with the Standard
 view transform, so there is no filmic roll-off to hide an overexposed scene. A measured failure: an
 800 W key at 2.8 m over 0.2-albedo surfaces put 48% of the frame at pure white.
 

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -75,6 +75,12 @@ import bpy primitives to do what they do — each exists because hand-rolling it
                                                  platform = on_surface(..., base);
                                                  plate = on_surface(..., platform)
     top_of(obj)                                  height of an object's upper face
+    strut(name, a, b, thickness, material_)      a limb spanning two POINTS, oriented for you.
+                                                 Build an arm from these: pick the joint
+                                                 positions, never the rotations
+    joint(name, at, radius, material_, axis)     a cylindrical hub at a joint
+    gripper(name, at, opening, material_)        two fingers `opening` apart, so the jaws close
+                                                 on the object rather than on air
     aim(obj, target)                             point an object's -Z at a point
     camera(location, target, lens=42.0)          camera looking at target, set as scene camera
     frame_all(cam)                               move the camera until everything fits

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -62,7 +62,24 @@ Blender 5.2 specifics that have already cost attempts, so get them right first t
   `mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value` directly.
 - `bpy.ops.mesh.primitive_*_add` operates on the active collection and sets the active object. For
   anything beyond a couple of bodies prefer `bpy.data.meshes.new` plus `bpy.data.objects.new` plus
-  `collection.objects.link`, which does not depend on operator context."""
+  `collection.objects.link`, which does not depend on operator context.
+- `bmesh.ops.create_cylinder` **does not exist**. Use `bmesh.ops.create_cone` with `radius1` equal
+  to `radius2`. The available primitives are `create_cube`, `create_cone`, `create_uvsphere`,
+  `create_icosphere`, `create_grid` and `create_circle`.
+
+**Lighting, which is where these renders keep failing.** The harness renders with the Standard view
+transform, so there is no filmic roll-off to hide an overexposed scene: what you light is what you
+get. A measured example — an 800 W key at 2.8 m over a bench of 0.2-albedo surfaces blew 48% of the
+frame to pure white.
+
+Sane starting points for a bench-scale scene in Cycles, lights 2 to 3 m from the subject:
+
+- key area light, 1.0-1.5 m size: **80-150 W**
+- fill area light, opposite side, 1.0 m size: **20-40 W**, and a cooler colour
+- world background strength: **0.05-0.2**
+
+Aim for a picture with real blacks and real whites and most of the image in between. If a surface
+is meant to read as dark grey, it needs both a low albedo and a light that does not overwhelm it."""
 
 CRITIC_SYSTEM = """You judge a rendered Blender scene against a brief, and you are hard to please.
 

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -59,6 +59,8 @@ import bpy primitives to do what they do — each exists because hand-rolling it
     material(name, color, roughness, metallic)   Principled material
     palette()                                    dict of measured preset materials, keyed:
                                                  bench 0.090  polymer 0.055  steel 0.420 metallic
+                                                 (metals are low-roughness on purpose: they need
+                                                 a big soft source to reflect or they read as paint)
                                                  aluminium 0.560 metallic   floor 0.300
                                                  labware 0.620   glass 0.800
     lab_lighting(target, cam)                    three-point rig placed off the CAMERA axis

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -77,6 +77,11 @@ Then `lab_lighting(target, cam)` LAST, after framing, passing the camera it retu
 places itself relative to the view axis so the light always models the form; lighting chosen in
 world space lands frontally as often as not and the render comes out flat.
 
+**A detail placed inside a solid body is invisible.** A slot modelled as its own box, positioned
+within the housing, renders as nothing and the instrument comes out a featureless block. To show a
+recess, either stand the detail 1-2 mm PROUD of the face in a darker material, or build the housing
+as panels around the opening. Never bury a mesh inside another.
+
 Where two bodies meet, **sink one a few millimetres into the other**. Surfaces that end at exactly
 the same height and overlap in plan will z-fight into flickering dark squares. A bench leg should
 reach up *into* the bench top, and every instrument on the bench goes through `on_surface`, which

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -92,6 +92,10 @@ import bpy primitives to do what they do — each exists because hand-rolling it
                                                  on the object rather than on air
     aim(obj, target)                             point an object's -Z at a point
     camera(location, target, lens=42.0)          camera looking at target, set as scene camera
+    three_quarter(target, side="left",           a three-quarter view from the named side. USE
+                  distance=3.2, height=1.6)      THIS when the brief describes a viewpoint: the
+                                                 scene faces -Y and front-left has been placed
+                                                 front-right more than once
     frame_all(cam)                               move the camera until everything fits
     frame_all(cam, distance=3.2)                 STAY at that range and solve for the lens
                                                  instead. Use this when the brief gives a

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -61,9 +61,13 @@ import bpy primitives to do what they do — each exists because hand-rolling it
     bench(name, width, depth, top_z=0.90,        a whole bench: top placed by its SURFACE height,
           top_material=, leg_material=)          legs reaching up into it. Use this, do not build
                                                  a bench out of boxes
-    on_surface(name, (x,y,z), (cx,cy), surf_z,   a body standing ON a surface, sunk 2 mm so it
-               material_)                        does not z-fight. USE THIS for anything on the
-                                                 bench: it computes the height for you
+    on_surface(name, (x,y,z), (cx,cy),           a body standing ON something, sunk 2 mm so it
+               surface, material_)                does not z-fight. `surface` is a height OR
+                                                 ANOTHER OBJECT, whose top face is measured.
+                                                 Stack with it: base = on_surface(..., 0.90);
+                                                 platform = on_surface(..., base);
+                                                 plate = on_surface(..., platform)
+    top_of(obj)                                  height of an object's upper face
     aim(obj, target)                             point an object's -Z at a point
     camera(location, target, lens=42.0)          camera looking at target, set as scene camera
     frame_all(cam)                               pull the camera back until everything fits

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -63,7 +63,10 @@ import bpy primitives to do what they do — each exists because hand-rolling it
                                                  a big soft source to reflect or they read as paint)
                                                  aluminium 0.560 metallic   floor 0.300
                                                  labware 0.620   glass 0.800
-    lab_lighting(target, cam)                    three-point rig placed off the CAMERA axis
+    lab_lighting(target, cam, side="left")       three-point rig placed off the CAMERA axis.
+                                                 `side` puts the key left or right AS SEEN FROM
+                                                 THE CAMERA, so a brief asking for a front-left
+                                                 key gets one. Do not place lights by hand
     box(name, (x,y,z), location, material_)      box of that size in metres, centred on location
     cylinder(name, radius, depth, location, m)   upright cylinder
     plane(name, size, location, material_)       flat square

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -50,7 +50,10 @@ import bpy primitives to do what they do — each exists because hand-rolling it
     new_scene()                                  empty scene WITH a world, returns the scene
     ambient(strength=0.1, color=(r,g,b))         world light; keep strength 0.05-0.2
     material(name, color, roughness, metallic)   Principled material
-    palette()                                    dict of measured preset materials
+    palette()                                    dict of measured preset materials, keyed:
+                                                 bench 0.090  polymer 0.055  steel 0.420 metallic
+                                                 aluminium 0.560 metallic   floor 0.300
+                                                 labware 0.620   glass 0.800
     lab_lighting(target, cam)                    three-point rig placed off the CAMERA axis
     box(name, (x,y,z), location, material_)      box of that size in metres, centred on location
     cylinder(name, radius, depth, location, m)   upright cylinder
@@ -87,6 +90,12 @@ handles this and computes the height so you never write `surface_z + height/2` b
 A swatch ramp was rendered to calibrate these. The finding worth knowing: the FLOOR dominates. At
 0.55 albedo it bounces so much light that even a 0.03 surface reads mid-grey and nothing can look
 dark. `p['floor']` is 0.30 for that reason. Do not brighten it.
+
+**Take the material from `p`, do not write your own for a surface it already covers.** The albedos
+above are what those words mean in this rig. A bench top written as 0.15 because it sounds like
+dark grey renders as mid grey and gets marked down for it — that has happened, twice. If you need
+something the palette lacks, keep it in the same range: matte dark polymer lives near 0.05, painted
+metal near 0.35, anything meant to read white near 0.65.
 
 **Lighting numbers, if you override the rig.** The harness renders with the Standard
 view transform, so there is no filmic roll-off to hide an overexposed scene. A measured failure: an

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -202,10 +202,10 @@ def run(
     model: str = DEFAULT_MODEL,
     key: str | None = None,
     blender: str | None = None,
-    width: int = 960,
-    height: int = 540,
-    engine: str = "BLENDER_EEVEE",
-    samples: int = 64,
+    width: int = 1280,
+    height: int = 720,
+    engine: str = "CYCLES",
+    samples: int = 256,
     on_step: object = None,
 ) -> list[Attempt]:
     """Drive the loop and leave every attempt on disk. Returns the attempts in order."""

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -53,6 +53,9 @@ import bpy primitives to do what they do — each exists because hand-rolling it
     box(name, (x,y,z), location, material_)      box of that size in metres, centred on location
     cylinder(name, radius, depth, location, m)   upright cylinder
     plane(name, size, location, material_)       flat square, for floors
+    on_surface(name, (x,y,z), (cx,cy), surf_z,   a body standing ON a surface, sunk 2 mm so it
+               material_)                        does not z-fight. USE THIS for anything on the
+                                                 bench: it computes the height for you
     aim(obj, target)                             point an object's -Z at a point
     camera(location, target, lens=42.0)          camera looking at target, set as scene camera
     frame_all(cam)                               pull the camera back until everything fits
@@ -66,7 +69,8 @@ Light with `area_light`.
 
 Where two bodies meet, **sink one a few millimetres into the other**. Surfaces that end at exactly
 the same height and overlap in plan will z-fight into flickering dark squares. A bench leg should
-reach up *into* the bench top, not stop level with its surface.
+reach up *into* the bench top, and every instrument on the bench goes through `on_surface`, which
+handles this and computes the height so you never write `surface_z + height/2` by hand.
 
 **Lighting numbers, because these renders keep blowing out.** The harness renders with the Standard
 view transform, so there is no filmic roll-off to hide an overexposed scene. A measured failure: an

--- a/scripts/scene_agent/loop.py
+++ b/scripts/scene_agent/loop.py
@@ -51,7 +51,7 @@ import bpy primitives to do what they do — each exists because hand-rolling it
     ambient(strength=0.1, color=(r,g,b))         world light; keep strength 0.05-0.2
     material(name, color, roughness, metallic)   Principled material
     palette()                                    dict of measured preset materials
-    lab_lighting(target)                         calibrated three-point rig
+    lab_lighting(target, cam)                    three-point rig placed off the CAMERA axis
     box(name, (x,y,z), location, material_)      box of that size in metres, centred on location
     cylinder(name, radius, depth, location, m)   upright cylinder
     plane(name, size, location, material_)       flat square, for floors
@@ -70,7 +70,9 @@ import bpy primitives to do what they do — each exists because hand-rolling it
 Start with `scene = new_scene()`. Build bodies with `box`, `cylinder` and `plane`. Frame with
 `cam = camera(...)` then `frame_all(cam)` as the last thing before lighting: it measures what you
 actually built and pulls back until none of it is cropped. Never write rotation_euler by hand.
-Light with `area_light`.
+Then `lab_lighting(target, cam)` LAST, after framing, passing the camera it returned. The rig
+places itself relative to the view axis so the light always models the form; lighting chosen in
+world space lands frontally as often as not and the render comes out flat.
 
 Where two bodies meet, **sink one a few millimetres into the other**. Surfaces that end at exactly
 the same height and overlap in plan will z-fight into flickering dark squares. A bench leg should

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -29,8 +29,37 @@ _ALIASES = {
     "target_location": "target", "look_at": "target",
 }
 
+def _by_type(value, signature, taken):
+    """Where a value of this kind belongs, when its name gave nothing away."""
+    import inspect
+
+    free = [n for n in signature.parameters if n not in taken]
+    if isinstance(value, bpy.types.Material):
+        for name in free:
+            if "material" in name:
+                return name
+        return None
+    if isinstance(value, (bpy.types.Object, list, tuple, set)):
+        for name in free:
+            if "surface" in name or "on" == name:
+                return name
+        for name in free:
+            if signature.parameters[name].default is inspect.Parameter.empty:
+                return name
+        return None
+    if isinstance(value, (int, float)):
+        for name in free:
+            default = signature.parameters[name].default
+            if isinstance(default, (int, float)) and not isinstance(default, bool):
+                return name
+        for name in free:
+            if "surface" in name:
+                return name
+    return None
+
 def _tolerant(func):
     """Accept the obvious synonyms for a parameter name rather than failing on one."""
+    import difflib
     import functools
     import inspect
 
@@ -48,6 +77,26 @@ def _tolerant(func):
             if given in names:
                 continue
             wanted = _ALIASES.get(given)
+            if wanted not in names:
+                # A fixed alias table does not keep up. The model has now invented `center`,
+                # `center_xy`, `surface_z` and `look_at` for parameters called `xy`, `surface` and
+                # `target`, and it will invent more. Match on containment first, since a compound
+                # name almost always contains the real one, then fall back to nearest spelling.
+                free = [n for n in names if n not in kwargs]
+                token = given.strip("_").lower()
+                hits = [
+                    n for n in free
+                    if n.strip("_").lower() in token or token in n.strip("_").lower()
+                ]
+                if hits:
+                    wanted = min(hits, key=len)
+                else:
+                    close = difflib.get_close_matches(token, free, n=1, cutoff=0.72)
+                    wanted = close[0] if close else None
+            if wanted is None:
+                # Name matching has a limit: `rests_on` does not resemble `surface` in any way a
+                # string comparison can see. What the value IS still says where it belongs.
+                wanted = _by_type(kwargs[given], signature, kwargs)
             if wanted and wanted in names and wanted not in kwargs:
                 kwargs[wanted] = kwargs.pop(given)
 

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -108,40 +108,65 @@ def camera(location, target, lens=42.0):
     bpy.context.scene.camera = obj
     return obj
 
-def frame_all(cam, margin=1.06, floor_names=("Floor",)):
-    """Pull `cam` back along its own axis until every body fits, then re-aim at their centre.
+def frame_all(cam, margin=1.04, floor_names=("Floor",)):
+    """Pull `cam` back until every body fits the frame, then re-aim at their centre.
 
-    Guessed camera distances crop things. This measures what is actually in the scene, ignoring
-    ground planes because they are meant to run past the frame.
+    Fits the actual bounding-box corners rather than a bounding sphere. A sphere is simple and
+    badly wrong for a bench: a 1.8 m wide, 0.9 m tall object has a 1.08 m bounding radius, and
+    fitting that radius to the *vertical* field of view puts the camera five metres away with the
+    subject small in a wide empty floor. Projecting the eight corners and solving for the worst one
+    is exact, and it is what a person framing a shot actually does.
 
-    The margin is deliberately tight. It is computed against the bounding sphere, which already
-    over-reserves for anything that is not a ball, so 1.25 left a bench sitting small in a wide
-    empty floor. Raise it only if something is genuinely being clipped.
+    Iterative because moving the camera changes the projection. It converges in two or three passes.
     """
+    import math
+
     bpy.context.view_layer.update()
     points = []
     for obj in bpy.data.objects:
         if obj.type != "MESH" or not obj.data.vertices:
             continue
-        if obj.name in floor_names or (obj.dimensions.z < 0.02 and max(obj.dimensions.x, obj.dimensions.y) > 4.0):
+        if obj.name in floor_names or (
+            obj.dimensions.z < 0.02 and max(obj.dimensions.x, obj.dimensions.y) > 4.0
+        ):
             continue
         points.extend(obj.matrix_world @ mathutils.Vector(c) for c in obj.bound_box)
     if not points:
         return cam
+
     lo = mathutils.Vector((min(p.x for p in points), min(p.y for p in points), min(p.z for p in points)))
     hi = mathutils.Vector((max(p.x for p in points), max(p.y for p in points), max(p.z for p in points)))
     centre = (lo + hi) / 2.0
-    radius = (hi - lo).length / 2.0
-    scene = bpy.context.scene
-    aspect = scene.render.resolution_x / max(scene.render.resolution_y, 1)
-    import math
-    half_fov = min(cam.data.angle / 2.0, math.atan(math.tan(cam.data.angle / 2.0) / max(aspect, 1e-6)))
-    distance = (radius * margin) / max(math.sin(half_fov), 1e-6)
-    direction = (cam.location - centre)
+
+    direction = cam.location - centre
     if direction.length < 1e-6:
         direction = mathutils.Vector((-1.0, -1.0, 0.6))
-    cam.location = centre + direction.normalized() * distance
+    direction = direction.normalized()
+
+    from bpy_extras.object_utils import world_to_camera_view
+
+    scene = bpy.context.scene
+    distance = max((cam.location - centre).length, 0.5)
+    for _ in range(6):
+        cam.location = centre + direction * distance
+        aim(cam, centre)
+        bpy.context.view_layer.update()
+        worst = 0.0
+        for point in points:
+            ndc = world_to_camera_view(scene, cam, point)
+            if ndc.z <= 0.0:
+                worst = max(worst, 4.0)
+                continue
+            worst = max(worst, abs(ndc.x - 0.5) * 2.0, abs(ndc.y - 0.5) * 2.0)
+        if worst <= 1e-6:
+            break
+        scale = worst * margin
+        if 0.98 < scale < 1.02:
+            break
+        distance *= scale
+    cam.location = centre + direction * distance
     aim(cam, centre)
+    bpy.context.view_layer.update()
     return cam
 
 def area_light(name, location, target, energy=120.0, size=1.2, color=(1.0, 0.98, 0.95)):

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -204,10 +204,23 @@ def cylinder(name, radius, depth, location, material_=None, segments=32):
     )
     return _mesh_object(name, bm, location, material_)
 
-def top_of(obj):
-    """The world-space height of an object's upper face."""
+def top_of(thing):
+    """The world-space height of the upper face of an object, or of a group of them.
+
+    Accepts an object, a list or tuple of objects, or a number passed straight through. `bench()`
+    and `studio()` both return tuples, so the natural thing to write is
+    `on_surface(..., surface=my_bench)` — and rejecting that costs an attempt for no reason. A
+    group returns its highest top, which is what "on top of the bench" means.
+    """
+    if isinstance(thing, (int, float)):
+        return float(thing)
     bpy.context.view_layer.update()
-    return max((obj.matrix_world @ mathutils.Vector(c)).z for c in obj.bound_box)
+    if isinstance(thing, (list, tuple, set)):
+        tops = [top_of(item) for item in thing if item is not None]
+        if not tops:
+            raise ValueError("top_of was given an empty group")
+        return max(tops)
+    return max((thing.matrix_world @ mathutils.Vector(c)).z for c in thing.bound_box)
 
 def on_surface(name, size, xy, surface, material_=None, sink=0.002):
     """A body standing on `surface`, sunk 2 mm so the faces do not z-fight.
@@ -220,7 +233,7 @@ def on_surface(name, size, xy, surface, material_=None, sink=0.002):
 
     `xy` is the centre in plan. Nothing here needs `surface_z + height/2` written by hand.
     """
-    surface_z = surface if isinstance(surface, (int, float)) else top_of(surface)
+    surface_z = top_of(surface)
     return box(name, size, (xy[0], xy[1], surface_z + size[2] / 2.0 - sink), material_)
 
 def plane(name, size, location=(0.0, 0.0, 0.0), material_=None):

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -64,20 +64,46 @@ def palette():
         for name, (colour, roughness, metallic) in PALETTE.items()
     }
 
-def lab_lighting(target=(0.0, 0.0, 1.0), key=90.0, fill=22.0):
-    """A three-point rig that exposes correctly under the Standard view transform.
+def lab_lighting(target=(0.0, 0.0, 1.0), cam=None, key=240.0, fill=60.0, rim=36.0):
+    """A three-point rig placed relative to the CAMERA, so the light always models the form.
 
-    Energies are measured against this palette: 90 W key and 22 W fill at roughly 2.5 to 3 m give
-    a mean luminance near 0.27 with nothing blown and nothing crushed. Higher numbers were what
-    produced a frame that was 48% pure white.
+    Lighting positioned in world space only works if the camera happens to be somewhere flattering.
+    A key that lands near the camera-to-subject axis lights everything frontally, kills every
+    shading gradient, and the render comes out looking like a diagram of the scene rather than a
+    photograph of it. That is a real critique this rig earned, twice.
+
+    So the key goes 50 degrees off the view axis and above; the fill goes to the other side at a
+    quarter of the power and slightly cool; a low rim behind picks the subject off the background.
+    Pass the camera returned by `camera()` or `frame_all()`. Call this AFTER framing.
+
+    The energies are set for lights standing off at roughly the camera distance. They are higher
+    than the earlier fixed-position rig because these sit further out, and light falls off with the
+    square of that distance.
     """
+    import math
+
     ambient(0.06)
     centre = mathutils.Vector(target)
-    k = area_light("Key", centre + mathutils.Vector((-1.8, -2.2, 1.9)), target,
-                   energy=key, size=1.4)
-    f = area_light("Fill", centre + mathutils.Vector((2.4, 1.2, 1.1)), target,
-                   energy=fill, size=1.0, color=(0.85, 0.90, 1.0))
-    return k, f
+    if cam is None:
+        cam = bpy.context.scene.camera
+    if cam is None:
+        offset = mathutils.Vector((-2.4, -2.4, 0.0))
+    else:
+        offset = cam.location - centre
+    reach = max(mathutils.Vector((offset.x, offset.y, 0.0)).length, 1.5)
+
+    def _at(degrees, height, distance):
+        angle = math.atan2(offset.y, offset.x) + math.radians(degrees)
+        return centre + mathutils.Vector(
+            (math.cos(angle) * distance, math.sin(angle) * distance, height)
+        )
+
+    k = area_light("Key", _at(50.0, reach * 0.95, reach * 1.05), target, energy=key, size=1.5)
+    f = area_light("Fill", _at(-75.0, reach * 0.45, reach * 1.15), target,
+                   energy=fill, size=1.1, color=(0.84, 0.89, 1.0))
+    r = area_light("Rim", _at(165.0, reach * 0.85, reach * 0.95), target,
+                   energy=rim, size=0.8, color=(0.92, 0.94, 1.0))
+    return k, f, r
 
 def _mesh_object(name, bm, location, material_):
     mesh = bpy.data.meshes.new(name)

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -18,6 +18,36 @@ import bpy
 import math
 import mathutils
 
+#: Names a caller might reasonably use for a parameter, mapped to the one the helper declares.
+#: A model that writes `center=` where the signature says `xy` is not wrong about what it means,
+#: and a TypeError for a synonym costs a whole attempt. It has cost three.
+_ALIASES = {
+    "center": "xy", "centre": "xy", "position": "xy", "at": "xy", "location": "xy",
+    "color": "colour", "mat": "material_", "material": "material_",
+    "surface_z": "surface", "on": "surface", "height": "surface",
+    "size_xyz": "size", "dimensions": "size", "dims": "size",
+    "target_location": "target", "look_at": "target",
+}
+
+def _tolerant(func):
+    """Accept the obvious synonyms for a parameter name rather than failing on one."""
+    import functools
+    import inspect
+
+    names = set(inspect.signature(func).parameters)
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        for given in list(kwargs):
+            if given in names:
+                continue
+            wanted = _ALIASES.get(given)
+            if wanted and wanted in names and wanted not in kwargs:
+                kwargs[wanted] = kwargs.pop(given)
+        return func(*args, **kwargs)
+
+    return wrapper
+
 def new_scene():
     """An empty scene with a world, which an empty factory reset does not give you."""
     bpy.ops.wm.read_factory_settings(use_empty=True)
@@ -374,4 +404,9 @@ def area_light(name, location, target, energy=120.0, size=1.2, color=(1.0, 0.98,
     bpy.context.collection.objects.link(obj)
     aim(obj, target)
     return obj
+for _name in (
+    "material", "box", "cylinder", "plane", "on_surface", "bench", "strut", "joint",
+    "gripper", "camera", "area_light", "lab_lighting", "frame_all", "studio",
+):
+    globals()[_name] = _tolerant(globals()[_name])
 '''

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -513,6 +513,22 @@ def frame_all(cam, margin=1.04, distance=None, floor_names=("Floor", "Backdrop")
     bpy.context.view_layer.update()
     return cam
 
+def three_quarter(target=(0.0, 0.0, 1.0), side="left", distance=3.2, height=1.6, lens=42.0):
+    """A three-quarter view from the named side, set as the scene camera.
+
+    The scene faces -Y, so front-left is negative in both X and Y. The model has placed the camera
+    front-right on a brief asking for front-left more than once, which is not a hard sum but is an
+    easy one to invert, and the answer is visible in every pixel of the result.
+
+    Follow with `frame_all(cam, distance=...)` to fit what you built.
+    """
+    centre = mathutils.Vector(target)
+    hand = -1.0 if str(side).lower().startswith("l") else 1.0
+    reach = distance / (2.0 ** 0.5)
+    return camera(
+        (centre.x + hand * reach, centre.y - reach, height), target, lens=lens
+    )
+
 def area_light(name, location, target, energy=120.0, size=1.2, color=(1.0, 0.98, 0.95)):
     """An area light aimed at `target`. 80-150 W for a key, 20-40 W for a fill, at 2-3 m."""
     data = bpy.data.lights.new(name=name, type="AREA")

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -181,6 +181,11 @@ PALETTE = {
     "floor":    ((0.300, 0.300, 0.310), 0.90, 0.0),
     "labware":  ((0.620, 0.620, 0.630), 0.45, 0.0),
     "glass":    ((0.800, 0.850, 0.860), 0.05, 0.0),
+    "worktop":  ((0.520, 0.470, 0.400), 0.55, 0.0),
+    "timber":   ((0.310, 0.210, 0.130), 0.65, 0.0),
+    "copper":   ((0.560, 0.290, 0.170), 0.24, 1.0),
+    "crate":    ((0.140, 0.260, 0.400), 0.70, 0.0),
+    "tile":     ((0.400, 0.380, 0.365), 0.45, 0.0),
 }
 
 def palette():
@@ -477,8 +482,104 @@ def gripper(name, at, opening, depth=0.09, thickness=0.012, height=0.05,
 #: rather than by size, which matters once a scene has a six-metre counter run that IS subject.
 SHELL_PREFIX = "Shell_"
 
+def tiled(name, colour=(0.42, 0.40, 0.38), grout=(0.26, 0.25, 0.24), tile=0.45,
+          roughness=0.45):
+    """A checkered floor material. Tile is most of what makes an interior read as a real room.
+
+    A flat grey floor is the single clearest tell that a render is a diagram. Real floors have a
+    grid, the grid gives the eye scale, and scale is what makes a room feel like a room rather than
+    a grey plane with objects on it. This is a checker rather than true grout lines, which is
+    cheaper and reads correctly at any distance a camera in the room will be.
+    """
+    mat = bpy.data.materials.new(name)
+    nodes, links = mat.node_tree.nodes, mat.node_tree.links
+    bsdf = nodes["Principled BSDF"]
+    checker = nodes.new("ShaderNodeTexChecker")
+    coords = nodes.new("ShaderNodeTexCoord")
+    checker.inputs["Color1"].default_value = (*colour, 1.0)
+    checker.inputs["Color2"].default_value = (*grout, 1.0)
+    # The checker has period 1 in scaled object space, and box() builds at real size with unit
+    # object scale, so object space is metres and the cell edge is 1/scale. Ask for the tile edge
+    # in metres, because that is the number anyone reasoning about a floor actually has.
+    checker.inputs["Scale"].default_value = 1.0 / max(float(tile), 1e-3)
+    links.new(coords.outputs["Object"], checker.inputs["Vector"])
+    links.new(checker.outputs["Color"], bsdf.inputs["Base Color"])
+    bsdf.inputs["Roughness"].default_value = roughness
+    return mat
+
+def daylight(direction=(-0.5, 0.7, -0.9), energy=3.5, warmth=(1.0, 0.95, 0.88), angle=0.02):
+    """A sun. Directional light is what gives an interior its shape.
+
+    Ceiling panels alone light a room evenly and evenly is the problem: no gradient, no cast
+    shadow, nothing to tell one surface from another. A sun through a window wall does what the
+    key light does outdoors, and it is the difference between a lit room and a diagram of one.
+    """
+    data = bpy.data.lights.new(name="Sun", type="SUN")
+    data.energy = energy
+    data.color = warmth
+    data.angle = angle
+    obj = bpy.data.objects.new("Sun", data)
+    bpy.context.collection.objects.link(obj)
+    obj.rotation_euler = mathutils.Vector(direction).to_track_quat("-Z", "Y").to_euler()
+    return obj
+
+def outside(shell, side="right", distance=6.0, brightness=3.0,
+            colour=(0.62, 0.72, 0.90), span=8.0):
+    """A lit plane beyond a glazed wall, so the window reads as daylight.
+
+    A window with nothing behind it renders as a black rectangle, which is worse than a blank wall:
+    the eye reads it as a hole. World background alone will not do it either, because the room is
+    sealed and the background is only visible through the opening at grazing angles. What works is
+    the thing that works on a film set — put a bright card outside the window.
+    """
+    bounds = _shell_bounds(shell)
+    if bounds is None:
+        bounds = ((-5.0, -5.0, 0.0), (5.0, 5.0, 3.2))
+    (lo_x, lo_y, lo_z), (hi_x, hi_y, hi_z) = bounds
+    w, d = hi_x - lo_x, hi_y - lo_y
+    size = max(w, d) * span
+    side = str(side).lower()
+    where = {
+        "right": ((hi_x + distance, (lo_y + hi_y) / 2.0, (lo_z + hi_z) / 2.0), (0.0, 1.5708, 0.0)),
+        "left": ((lo_x - distance, (lo_y + hi_y) / 2.0, (lo_z + hi_z) / 2.0), (0.0, 1.5708, 0.0)),
+        "back": (((lo_x + hi_x) / 2.0, hi_y + distance, (lo_z + hi_z) / 2.0), (1.5708, 0.0, 0.0)),
+        "front": (((lo_x + hi_x) / 2.0, lo_y - distance, (lo_z + hi_z) / 2.0), (1.5708, 0.0, 0.0)),
+    }[side]
+    mat = bpy.data.materials.new("Outside")
+    nodes, links = mat.node_tree.nodes, mat.node_tree.links
+    emission = nodes.new("ShaderNodeEmission")
+    emission.inputs["Color"].default_value = (*colour, 1.0)
+    emission.inputs["Strength"].default_value = brightness
+    links.new(emission.outputs["Emission"], nodes["Material Output"].inputs["Surface"])
+    obj = plane(f"{SHELL_PREFIX}Outside_{side.title()}", size, where[0], mat)
+    obj.rotation_euler = where[1]
+    # The card catches rays that leave through the window roughly square-on. A ray leaving at a
+    # grazing angle overshoots any finite card, and that ray is the one through the window furthest
+    # from the camera, so the far windows are exactly the ones that come back black. Tint the world
+    # to the same colour as the backstop for everything the card misses.
+    # Calibrated: at 0.25x the card brightness the world alone lifted the ceiling to white and
+    # blew 8% of the frame. The card is the light; the sky is only there to fill the rays that
+    # miss it, so it wants to be dim enough that a sealed room does not notice it.
+    ambient(strength=min(brightness * 0.12, 0.5), color=colour)
+    return obj
+
+def _shell_bounds(shell):
+    """The world-space extent of whatever room() returned, or None if it holds no meshes."""
+    pts = []
+    for body in (shell.values() if isinstance(shell, dict) else shell):
+        for candidate in (body if isinstance(body, (list, tuple)) else [body]):
+            if getattr(candidate, "bound_box", None) is None:
+                continue
+            pts.extend(candidate.matrix_world @ mathutils.Vector(c) for c in candidate.bound_box)
+    if not pts:
+        return None
+    return (
+        (min(v.x for v in pts), min(v.y for v in pts), min(v.z for v in pts)),
+        (max(v.x for v in pts), max(v.y for v in pts), max(v.z for v in pts)),
+    )
+
 def room(width=9.0, depth=7.0, height=3.2, floor_material=None, wall_material=None,
-         ceiling_material=None, open_side="front", thickness=0.12):
+         ceiling_material=None, open_side="front", thickness=0.12, glazed=None):
     """An interior: floor, ceiling and walls, with one side left open for the camera.
 
     Bench scenes stand an object on a ground plane and look at it from outside. A room is the
@@ -502,8 +603,38 @@ def room(width=9.0, depth=7.0, height=3.2, floor_material=None, wall_material=No
         "left": ((thickness, depth, height), (-half_w, 0.0, height / 2.0)),
         "right": ((thickness, depth, height), (half_w, 0.0, height / 2.0)),
     }
+    glass = str(glazed).lower() if glazed else None
     for side, (size, where) in walls.items():
         if side == str(open_side).lower():
+            continue
+        if side == glass:
+            # A wall with a band of openings: sill below, header above, mullions between. The
+            # daylight that makes an interior look photographed has to get in somewhere.
+            sill, head = 0.95, 2.45
+            horiz = side in ("back", "front")
+            span = width if horiz else depth
+            lo = (0.0, where[1]) if horiz else (where[0], 0.0)
+            built[f"{side}_sill"] = box(
+                f"{SHELL_PREFIX}Wall_{side.title()}_Sill",
+                (span, thickness, sill) if horiz else (thickness, span, sill),
+                (lo[0], lo[1], sill / 2.0) if horiz else (lo[0], lo[1], sill / 2.0),
+                wall_material,
+            )
+            built[f"{side}_head"] = box(
+                f"{SHELL_PREFIX}Wall_{side.title()}_Head",
+                (span, thickness, height - head) if horiz else (thickness, span, height - head),
+                (lo[0], lo[1], (height + head) / 2.0),
+                wall_material,
+            )
+            for m in range(5):
+                f = (m + 1) / 6.0
+                mx = (-span / 2.0 + span * f, lo[1]) if horiz else (lo[0], -span / 2.0 + span * f)
+                built[f"{side}_mullion{m}"] = box(
+                    f"{SHELL_PREFIX}Wall_{side.title()}_Mullion{m}",
+                    (0.06, thickness, head - sill) if horiz else (thickness, 0.06, head - sill),
+                    (mx[0], mx[1], (sill + head) / 2.0),
+                    wall_material,
+                )
             continue
         built[side] = box(f"{SHELL_PREFIX}Wall_{side.title()}", size, where, wall_material)
     return built

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -96,11 +96,15 @@ def camera(location, target, lens=42.0):
     bpy.context.scene.camera = obj
     return obj
 
-def frame_all(cam, margin=1.25, floor_names=("Floor",)):
+def frame_all(cam, margin=1.06, floor_names=("Floor",)):
     """Pull `cam` back along its own axis until every body fits, then re-aim at their centre.
 
     Guessed camera distances crop things. This measures what is actually in the scene, ignoring
     ground planes because they are meant to run past the frame.
+
+    The margin is deliberately tight. It is computed against the bounding sphere, which already
+    over-reserves for anything that is not a ball, so 1.25 left a bench sitting small in a wide
+    empty floor. Raise it only if something is genuinely being clipped.
     """
     bpy.context.view_layer.update()
     points = []

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -241,6 +241,21 @@ def gripper(name, at, opening, depth=0.09, thickness=0.012, height=0.05,
         for tag, offset in zip(("L", "R"), offsets)
     ]
 
+def studio(size=60.0, material_=None, sweep=True):
+    """A ground plane large enough that its edge never enters frame, with an optional sweep.
+
+    A 10 m floor looks generous until the camera tilts up and catches its far edge, which reads as
+    a hard diagonal seam across the background. A product photograph solves this with a cyclorama:
+    floor and wall meeting in a curve so there is no horizon at all. The cheap version is a very
+    large floor plus a wall far enough back to fall outside the frame, sharing one material so no
+    join is visible.
+    """
+    ground = plane("Floor", size, (0.0, 0.0, 0.0), material_)
+    if sweep:
+        wall = box("Backdrop", (size, 0.05, size * 0.4), (0.0, size * 0.25, size * 0.2), material_)
+        return ground, wall
+    return ground, None
+
 def aim(obj, target):
     """Point an object's -Z at `target`. Accepts a tuple or a Vector, which is the whole point."""
     direction = mathutils.Vector(target) - obj.location
@@ -258,7 +273,7 @@ def camera(location, target, lens=42.0):
     bpy.context.scene.camera = obj
     return obj
 
-def frame_all(cam, margin=1.04, distance=None, floor_names=("Floor",)):
+def frame_all(cam, margin=1.04, distance=None, floor_names=("Floor", "Backdrop")):
     """Pull `cam` back until every body fits the frame, then re-aim at their centre.
 
     Fits the actual bounding-box corners rather than a bounding sphere. A sphere is simple and
@@ -282,9 +297,9 @@ def frame_all(cam, margin=1.04, distance=None, floor_names=("Floor",)):
     for obj in bpy.data.objects:
         if obj.type != "MESH" or not obj.data.vertices:
             continue
-        if obj.name in floor_names or (
-            obj.dimensions.z < 0.02 and max(obj.dimensions.x, obj.dimensions.y) > 4.0
-        ):
+        # Scenery is not subject. A floor or a backdrop is there to be behind things, and
+        # including it in the fit sends the camera far enough away to see all sixty metres of it.
+        if obj.name in floor_names or max(obj.dimensions) > 5.0:
             continue
         points.extend(obj.matrix_world @ mathutils.Vector(c) for c in obj.bound_box)
     if not points:

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -15,6 +15,7 @@ Injected before the candidate, so every name below is already defined when its f
 PRELUDE = '''
 import bmesh
 import bpy
+import math
 import mathutils
 
 def new_scene():
@@ -185,6 +186,60 @@ def bench(name, width, depth, top_z=0.90, thickness=0.04, leg=0.05,
             box(f"{name}_Leg_{tag}", (leg, leg, leg_height), (lx, ly, leg_height / 2.0), leg_material)
         )
     return top, legs
+
+def strut(name, a, b, thickness=0.06, material_=None, overlap=0.0):
+    """A square limb spanning from point `a` to point `b`, correctly oriented.
+
+    An articulated arm is the case where hand-written orientation goes wrong every time: the model
+    has to pick a rotation for each segment, and a rotation that is wrong by a sign puts the forearm
+    through the bench. Given two points there is no rotation to choose.
+
+    `overlap` extends the segment past both ends, which is how you make joints look continuous
+    instead of leaving daylight between a limb and its hub.
+
+    Returns the object, so a chain is just a sequence of struts between joint positions.
+    """
+    start = mathutils.Vector(a)
+    end = mathutils.Vector(b)
+    span = end - start
+    length = span.length
+    if length < 1e-6:
+        return box(name, (thickness, thickness, thickness), start, material_)
+    obj = box(name, (thickness, thickness, length + overlap * 2.0), (0.0, 0.0, 0.0), material_)
+    obj.location = (start + end) / 2.0
+    obj.rotation_euler = span.to_track_quat("Z", "Y").to_euler()
+    bpy.context.view_layer.update()
+    return obj
+
+def joint(name, at, radius=0.045, depth=None, material_=None, axis="Z"):
+    """A cylindrical hub at a joint position, so limbs meet in something rather than in mid-air."""
+    obj = cylinder(name, radius, depth if depth is not None else radius * 2.2, at, material_)
+    if axis.upper() == "Y":
+        obj.rotation_euler = (math.radians(90.0), 0.0, 0.0)
+    elif axis.upper() == "X":
+        obj.rotation_euler = (0.0, math.radians(90.0), 0.0)
+    bpy.context.view_layer.update()
+    return obj
+
+def gripper(name, at, opening, depth=0.09, thickness=0.012, height=0.05,
+            material_=None, along="x"):
+    """Two parallel fingers `opening` apart, centred on `at`, bracketing whatever sits between them.
+
+    Made as a pair because the failure it prevents is jaws that close on empty air: give it the
+    width of the thing being held and the fingers land on its faces.
+    """
+    centre = mathutils.Vector(at)
+    half = opening / 2.0 + thickness / 2.0
+    offsets = (
+        (mathutils.Vector((-half, 0.0, 0.0)), mathutils.Vector((half, 0.0, 0.0)))
+        if along == "x"
+        else (mathutils.Vector((0.0, -half, 0.0)), mathutils.Vector((0.0, half, 0.0)))
+    )
+    size = (thickness, depth, height) if along == "x" else (depth, thickness, height)
+    return [
+        box(f"{name}_{tag}", size, centre + offset, material_)
+        for tag, offset in zip(("L", "R"), offsets)
+    ]
 
 def aim(obj, target):
     """Point an object's -Z at `target`. Accepts a tuple or a Vector, which is the whole point."""

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -96,6 +96,38 @@ def camera(location, target, lens=42.0):
     bpy.context.scene.camera = obj
     return obj
 
+def frame_all(cam, margin=1.25, floor_names=("Floor",)):
+    """Pull `cam` back along its own axis until every body fits, then re-aim at their centre.
+
+    Guessed camera distances crop things. This measures what is actually in the scene, ignoring
+    ground planes because they are meant to run past the frame.
+    """
+    bpy.context.view_layer.update()
+    points = []
+    for obj in bpy.data.objects:
+        if obj.type != "MESH" or not obj.data.vertices:
+            continue
+        if obj.name in floor_names or (obj.dimensions.z < 0.02 and max(obj.dimensions.x, obj.dimensions.y) > 4.0):
+            continue
+        points.extend(obj.matrix_world @ mathutils.Vector(c) for c in obj.bound_box)
+    if not points:
+        return cam
+    lo = mathutils.Vector((min(p.x for p in points), min(p.y for p in points), min(p.z for p in points)))
+    hi = mathutils.Vector((max(p.x for p in points), max(p.y for p in points), max(p.z for p in points)))
+    centre = (lo + hi) / 2.0
+    radius = (hi - lo).length / 2.0
+    scene = bpy.context.scene
+    aspect = scene.render.resolution_x / max(scene.render.resolution_y, 1)
+    import math
+    half_fov = min(cam.data.angle / 2.0, math.atan(math.tan(cam.data.angle / 2.0) / max(aspect, 1e-6)))
+    distance = (radius * margin) / max(math.sin(half_fov), 1e-6)
+    direction = (cam.location - centre)
+    if direction.length < 1e-6:
+        direction = mathutils.Vector((-1.0, -1.0, 0.6))
+    cam.location = centre + direction.normalized() * distance
+    aim(cam, centre)
+    return cam
+
 def area_light(name, location, target, energy=120.0, size=1.2, color=(1.0, 0.98, 0.95)):
     """An area light aimed at `target`. 80-150 W for a key, 20-40 W for a fill, at 2-3 m."""
     data = bpy.data.lights.new(name=name, type="AREA")

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -127,6 +127,32 @@ def plane(name, size, location=(0.0, 0.0, 0.0), material_=None):
     bmesh.ops.create_grid(bm, x_segments=1, y_segments=1, size=size / 2.0)
     return _mesh_object(name, bm, location, material_)
 
+def bench(name, width, depth, top_z=0.90, thickness=0.04, leg=0.05,
+          top_material=None, leg_material=None, inset=0.05):
+    """A bench whose top SURFACE is at `top_z`, with legs that reach up into it.
+
+    Three recurring errors disappear here. The top is placed by its surface rather than its centre,
+    so `top_z + thickness/2` is never written by hand and the bench does not end up 40 mm too tall.
+    The legs run from the floor to just under the surface and overlap the top by a third of its
+    thickness, so their faces never share a plane with it and cannot z-fight. And the leg inset is
+    handled, so feet sit under the top rather than flush with its edge.
+
+    Returns (top, [legs]).
+    """
+    top = box(name, (width, depth, thickness), (0.0, 0.0, top_z - thickness / 2.0), top_material)
+    overlap = thickness / 3.0
+    leg_height = top_z - thickness + overlap
+    x = width / 2.0 - inset - leg / 2.0
+    y = depth / 2.0 - inset - leg / 2.0
+    legs = []
+    for tag, (lx, ly) in {
+        "FL": (-x, -y), "FR": (x, -y), "BL": (-x, y), "BR": (x, y),
+    }.items():
+        legs.append(
+            box(f"{name}_Leg_{tag}", (leg, leg, leg_height), (lx, ly, leg_height / 2.0), leg_material)
+        )
+    return top, legs
+
 def aim(obj, target):
     """Point an object's -Z at `target`. Accepts a tuple or a Vector, which is the whole point."""
     direction = mathutils.Vector(target) - obj.location

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -73,6 +73,18 @@ def cylinder(name, radius, depth, location, material_=None, segments=32):
     )
     return _mesh_object(name, bm, location, material_)
 
+def on_surface(name, size, xy, surface_z, material_=None, sink=0.002):
+    """A body standing on a surface at `surface_z`, sunk 2 mm so the faces do not z-fight.
+
+    This is the most common placement in a lab scene and the easiest to get wrong: an instrument
+    whose underside sits at exactly the height of the bench top shares a plane with it, and the two
+    surfaces flicker against each other. Sinking it slightly is what a real object does anyway,
+    since nothing rests on a surface without deforming into it a little.
+
+    `xy` is the centre in plan; the height is computed, so there is no arithmetic to get wrong.
+    """
+    return box(name, size, (xy[0], xy[1], surface_z + size[2] / 2.0 - sink), material_)
+
 def plane(name, size, location=(0.0, 0.0, 0.0), material_=None):
     """A flat square, for floors."""
     bm = bmesh.new()

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -203,7 +203,7 @@ def camera(location, target, lens=42.0):
     bpy.context.scene.camera = obj
     return obj
 
-def frame_all(cam, margin=1.04, floor_names=("Floor",)):
+def frame_all(cam, margin=1.04, distance=None, floor_names=("Floor",)):
     """Pull `cam` back until every body fits the frame, then re-aim at their centre.
 
     Fits the actual bounding-box corners rather than a bounding sphere. A sphere is simple and
@@ -213,6 +213,12 @@ def frame_all(cam, margin=1.04, floor_names=("Floor",)):
     is exact, and it is what a person framing a shot actually does.
 
     Iterative because moving the camera changes the projection. It converges in two or three passes.
+
+    Pass `distance` to stand at a chosen range and solve for the LENS instead of moving. That is how
+    a brief specifying "3.2 m from the bench" should be met, and it removes an interaction that is
+    easy to get backwards: a longer lens is narrower, so it needs MORE room, not less. One attempt
+    reached for a 65 mm lens reasoning that it would let the camera come closer, and ended up at
+    5.4 m on a brief asking for 3.2.
     """
     import math
 
@@ -241,6 +247,29 @@ def frame_all(cam, margin=1.04, floor_names=("Floor",)):
     from bpy_extras.object_utils import world_to_camera_view
 
     scene = bpy.context.scene
+
+    if distance is not None:
+        # Stand at the requested range and choose the lens that fits. Widen until nothing is
+        # outside the frame; the sensor is 36 mm, so lens = 18 / tan(half-angle).
+        cam.location = centre + direction * float(distance)
+        aim(cam, centre)
+        for _ in range(8):
+            bpy.context.view_layer.update()
+            worst = 0.0
+            for point in points:
+                ndc = world_to_camera_view(scene, cam, point)
+                if ndc.z <= 0.0:
+                    worst = max(worst, 4.0)
+                    continue
+                worst = max(worst, abs(ndc.x - 0.5) * 2.0, abs(ndc.y - 0.5) * 2.0)
+            if abs(worst * margin - 1.0) < 0.02:
+                break
+            half = math.atan(18.0 / max(cam.data.lens, 1.0))
+            half = math.atan(math.tan(half) * worst * margin)
+            cam.data.lens = max(8.0, min(200.0, 18.0 / max(math.tan(half), 1e-6)))
+        bpy.context.view_layer.update()
+        return cam
+
     distance = max((cam.location - centre).length, 0.5)
     for _ in range(6):
         cam.location = centre + direction * distance

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -36,6 +36,12 @@ def _tolerant(func):
 
     names = set(inspect.signature(func).parameters)
 
+    signature = inspect.signature(func)
+    material_params = [
+        n for n, param in signature.parameters.items()
+        if n.startswith("material") or n.endswith("material") or n.endswith("material_")
+    ]
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         for given in list(kwargs):
@@ -44,6 +50,33 @@ def _tolerant(func):
             wanted = _ALIASES.get(given)
             if wanted and wanted in names and wanted not in kwargs:
                 kwargs[wanted] = kwargs.pop(given)
+
+        # A material handed to a numeric parameter is a positional slip, not a type error worth
+        # dying on: `bench(name, w, d, top_material, leg_material)` skips `top_z` and `thickness`
+        # and lands a Material where a float belongs. Move it to the first free material slot and
+        # let the numeric parameter keep its default.
+        if material_params:
+            bound = list(args)
+            positional = [
+                n for n in signature.parameters
+                if signature.parameters[n].kind
+                in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+            ]
+            spare = [n for n in material_params if n not in kwargs]
+            keep = []
+            for index, value in enumerate(bound):
+                slot = positional[index] if index < len(positional) else None
+                if (
+                    isinstance(value, bpy.types.Material)
+                    and slot is not None
+                    and slot not in material_params
+                    and spare
+                ):
+                    kwargs[spare.pop(0)] = value
+                    continue
+                keep.append(value)
+            bound = keep
+            return func(*bound, **kwargs)
         return func(*args, **kwargs)
 
     return wrapper

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -135,16 +135,23 @@ def cylinder(name, radius, depth, location, material_=None, segments=32):
     )
     return _mesh_object(name, bm, location, material_)
 
-def on_surface(name, size, xy, surface_z, material_=None, sink=0.002):
-    """A body standing on a surface at `surface_z`, sunk 2 mm so the faces do not z-fight.
+def top_of(obj):
+    """The world-space height of an object's upper face."""
+    bpy.context.view_layer.update()
+    return max((obj.matrix_world @ mathutils.Vector(c)).z for c in obj.bound_box)
 
-    This is the most common placement in a lab scene and the easiest to get wrong: an instrument
-    whose underside sits at exactly the height of the bench top shares a plane with it, and the two
-    surfaces flicker against each other. Sinking it slightly is what a real object does anyway,
-    since nothing rests on a surface without deforming into it a little.
+def on_surface(name, size, xy, surface, material_=None, sink=0.002):
+    """A body standing on `surface`, sunk 2 mm so the faces do not z-fight.
 
-    `xy` is the centre in plan; the height is computed, so there is no arithmetic to get wrong.
+    `surface` is either a height in metres or **another object**, in which case its upper face is
+    measured. Passing the object is what you want when stacking: a shaker is a base, then a platform
+    on the base, then a plate on the platform, then clamps on the platform, and every one of those
+    heights is a chance to bury a body inside the one below it. That has happened — a platform and a
+    microplate both ended up inside the shaker base, which renders as a plain block.
+
+    `xy` is the centre in plan. Nothing here needs `surface_z + height/2` written by hand.
     """
+    surface_z = surface if isinstance(surface, (int, float)) else top_of(surface)
     return box(name, size, (xy[0], xy[1], surface_z + size[2] / 2.0 - sink), material_)
 
 def plane(name, size, location=(0.0, 0.0, 0.0), material_=None):

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -305,6 +305,47 @@ def on_surface(name, size, xy, surface, material_=None, sink=0.002):
     surface_z = top_of(surface)
     return box(name, size, (xy[0], xy[1], surface_z + size[2] / 2.0 - sink), material_)
 
+def face_detail(name, parent, size, where="front", offset=(0.0, 0.0),
+                material_=None, proud=0.004):
+    """A slot, panel or vent on one FACE of a body, standing slightly proud of it.
+
+    Three things have to be right at once and the model has got each of them wrong: the feature has
+    to be on a face the camera can see, it has to break the surface rather than sit inside the
+    solid, and it must not end flush with the parent or the two will z-fight. All three follow from
+    the parent's own bounding box, so none of them needs deciding.
+
+    `where` is "front", "back", "left", "right" or "top" in scene terms, where front is -Y, which
+    is the side a three-quarter view looks at. `offset` shifts the feature across that face.
+
+    Pass `where="camera"` to put it on whichever face the scene camera is actually looking at.
+    """
+    bpy.context.view_layer.update()
+    pts = [parent.matrix_world @ mathutils.Vector(c) for c in parent.bound_box]
+    lo = mathutils.Vector((min(p.x for p in pts), min(p.y for p in pts), min(p.z for p in pts)))
+    hi = mathutils.Vector((max(p.x for p in pts), max(p.y for p in pts), max(p.z for p in pts)))
+    mid = (lo + hi) / 2.0
+
+    face = str(where).lower()
+    if face == "camera":
+        cam = bpy.context.scene.camera
+        if cam is None:
+            face = "front"
+        else:
+            view = cam.matrix_world.translation - mid
+            face = ("right" if view.x > 0 else "left") if abs(view.x) > abs(view.y) else (
+                "back" if view.y > 0 else "front"
+            )
+
+    depth = size[1] if face in ("front", "back") else size[0] if face in ("left", "right") else size[2]
+    place = {
+        "front": (mid.x + offset[0], lo.y - depth / 2.0 + proud, mid.z + offset[1]),
+        "back": (mid.x + offset[0], hi.y + depth / 2.0 - proud, mid.z + offset[1]),
+        "left": (lo.x - depth / 2.0 + proud, mid.y + offset[0], mid.z + offset[1]),
+        "right": (hi.x + depth / 2.0 - proud, mid.y + offset[0], mid.z + offset[1]),
+        "top": (mid.x + offset[0], mid.y + offset[1], hi.z + depth / 2.0 - proud),
+    }[face]
+    return box(name, size, place, material_)
+
 def plane(name, size, location=(0.0, 0.0, 0.0), material_=None):
     """A flat square, for floors."""
     bm = bmesh.new()

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -219,7 +219,7 @@ def lab_lighting(target=(0.0, 0.0, 1.0), cam=None, key=300.0, fill=75.0, rim=45.
     import math
 
     ambient(0.06)
-    centre = mathutils.Vector(target)
+    centre = point_of(target)
     if cam is None:
         cam = bpy.context.scene.camera
     if cam is None:
@@ -248,7 +248,7 @@ def _mesh_object(name, bm, location, material_):
     bm.to_mesh(mesh)
     bm.free()
     obj = bpy.data.objects.new(name, mesh)
-    obj.location = mathutils.Vector(location)
+    obj.location = point_of(location)
     if material_ is not None:
         obj.data.materials.append(material_)
     bpy.context.collection.objects.link(obj)
@@ -272,6 +272,28 @@ def cylinder(name, radius, depth, location, material_=None, segments=32):
         radius1=radius, radius2=radius, depth=depth,
     )
     return _mesh_object(name, bm, location, material_)
+
+def point_of(thing):
+    """A point, from a point, an object, or a group of objects.
+
+    "Look at the bench" is a reasonable thing to mean and the model means it: it passes an object
+    where a location belongs and mathutils reports `sequence index 0 expected a number, found
+    'Object' type`, which names neither the call nor the argument. An object resolves to the centre
+    of what it occupies, a group to the centre of all of it.
+    """
+    if isinstance(thing, mathutils.Vector):
+        return thing.copy()
+    if isinstance(thing, bpy.types.Object):
+        bpy.context.view_layer.update()
+        pts = [thing.matrix_world @ mathutils.Vector(c) for c in thing.bound_box]
+        return sum(pts, mathutils.Vector()) / len(pts)
+    if isinstance(thing, (list, tuple, set)):
+        items = [i for i in thing if i is not None]
+        if items and all(isinstance(i, bpy.types.Object) for i in items):
+            pts = [point_of(i) for i in items]
+            return sum(pts, mathutils.Vector()) / len(pts)
+        return mathutils.Vector(tuple(thing))
+    return mathutils.Vector(thing)
 
 def top_of(thing):
     """The world-space height of the upper face of an object, or of a group of them.
@@ -390,8 +412,8 @@ def strut(name, a, b, thickness=0.06, material_=None, overlap=0.0):
 
     Returns the object, so a chain is just a sequence of struts between joint positions.
     """
-    start = mathutils.Vector(a)
-    end = mathutils.Vector(b)
+    start = point_of(a)
+    end = point_of(b)
     span = end - start
     length = span.length
     if length < 1e-6:
@@ -419,7 +441,7 @@ def gripper(name, at, opening, depth=0.09, thickness=0.012, height=0.05,
     Made as a pair because the failure it prevents is jaws that close on empty air: give it the
     width of the thing being held and the fingers land on its faces.
     """
-    centre = mathutils.Vector(at)
+    centre = point_of(at)
     half = opening / 2.0 + thickness / 2.0
     offsets = (
         (mathutils.Vector((-half, 0.0, 0.0)), mathutils.Vector((half, 0.0, 0.0)))
@@ -449,7 +471,7 @@ def studio(size=60.0, material_=None, sweep=True):
 
 def aim(obj, target):
     """Point an object's -Z at `target`. Accepts a tuple or a Vector, which is the whole point."""
-    direction = mathutils.Vector(target) - obj.location
+    direction = point_of(target) - obj.location
     obj.rotation_euler = direction.to_track_quat("-Z", "Y").to_euler()
     return obj
 
@@ -458,7 +480,7 @@ def camera(location, target, lens=42.0):
     data = bpy.data.cameras.new("Camera")
     data.lens = lens
     obj = bpy.data.objects.new("Camera", data)
-    obj.location = mathutils.Vector(location)
+    obj.location = point_of(location)
     bpy.context.collection.objects.link(obj)
     aim(obj, target)
     bpy.context.scene.camera = obj
@@ -563,7 +585,7 @@ def three_quarter(target=(0.0, 0.0, 1.0), side="left", distance=3.2, height=1.6,
 
     Follow with `frame_all(cam, distance=...)` to fit what you built.
     """
-    centre = mathutils.Vector(target)
+    centre = point_of(target)
     hand = -1.0 if str(side).lower().startswith("l") else 1.0
     reach = distance / (2.0 ** 0.5)
     return camera(
@@ -577,7 +599,7 @@ def area_light(name, location, target, energy=120.0, size=1.2, color=(1.0, 0.98,
     data.size = size
     data.color = color
     obj = bpy.data.objects.new(name, data)
-    obj.location = mathutils.Vector(location)
+    obj.location = point_of(location)
     bpy.context.collection.objects.link(obj)
     aim(obj, target)
     return obj

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -288,9 +288,23 @@ def point_of(thing):
         pts = [thing.matrix_world @ mathutils.Vector(c) for c in thing.bound_box]
         return sum(pts, mathutils.Vector()) / len(pts)
     if isinstance(thing, (list, tuple, set)):
-        items = [i for i in thing if i is not None]
-        if items and all(isinstance(i, bpy.types.Object) for i in items):
-            pts = [point_of(i) for i in items]
+        # Groups nest. `bench()` returns (top, [legs]), so a caller writing
+        # `three_quarter(my_bench)` hands over an object AND a list in one tuple, and a flat
+        # all-objects test misses it and falls through to a raw Vector that fails naming neither.
+        flat = []
+
+        def _walk(item):
+            if item is None:
+                return
+            if isinstance(item, bpy.types.Object):
+                flat.append(item)
+            elif isinstance(item, (list, tuple, set)):
+                for inner in item:
+                    _walk(inner)
+
+        _walk(thing)
+        if flat:
+            pts = [point_of(obj) for obj in flat]
             return sum(pts, mathutils.Vector()) / len(pts)
         return mathutils.Vector(tuple(thing))
     return mathutils.Vector(thing)
@@ -311,6 +325,11 @@ def top_of(thing):
         if not tops:
             raise ValueError("top_of was given an empty group")
         return max(tops)
+    if not hasattr(thing, "bound_box"):
+        raise TypeError(
+            f"top_of cannot measure {type(thing).__name__}; pass an object, a group of them, "
+            "or a height in metres"
+        )
     return max((thing.matrix_world @ mathutils.Vector(c)).z for c in thing.bound_box)
 
 def on_surface(name, size, xy, surface, material_=None, sink=0.002):

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -473,6 +473,94 @@ def gripper(name, at, opening, depth=0.09, thickness=0.012, height=0.05,
         for tag, offset in zip(("L", "R"), offsets)
     ]
 
+#: Shell bodies are the room itself. They are named so the checks can classify them by intent
+#: rather than by size, which matters once a scene has a six-metre counter run that IS subject.
+SHELL_PREFIX = "Shell_"
+
+def room(width=9.0, depth=7.0, height=3.2, floor_material=None, wall_material=None,
+         ceiling_material=None, open_side="front", thickness=0.12):
+    """An interior: floor, ceiling and walls, with one side left open for the camera.
+
+    Bench scenes stand an object on a ground plane and look at it from outside. A room is the
+    opposite problem — the camera lives inside, the walls are what stop the light escaping, and the
+    thing that makes it read as a room is the boundary rather than the furniture.
+
+    `open_side` omits one wall so a camera outside that face can see in without a clipping plane.
+    Every body is named `Shell_*` so the checks know it is the room and not a thing in the room.
+
+    Returns a dict: floor, ceiling, and the walls that were built.
+    """
+    half_w, half_d = width / 2.0, depth / 2.0
+    built = {}
+    built["floor"] = box(f"{SHELL_PREFIX}Floor", (width, depth, thickness),
+                         (0.0, 0.0, -thickness / 2.0), floor_material)
+    built["ceiling"] = box(f"{SHELL_PREFIX}Ceiling", (width, depth, thickness),
+                           (0.0, 0.0, height + thickness / 2.0), ceiling_material)
+    walls = {
+        "back": ((width, thickness, height), (0.0, half_d, height / 2.0)),
+        "front": ((width, thickness, height), (0.0, -half_d, height / 2.0)),
+        "left": ((thickness, depth, height), (-half_w, 0.0, height / 2.0)),
+        "right": ((thickness, depth, height), (half_w, 0.0, height / 2.0)),
+    }
+    for side, (size, where) in walls.items():
+        if side == str(open_side).lower():
+            continue
+        built[side] = box(f"{SHELL_PREFIX}Wall_{side.title()}", size, where, wall_material)
+    return built
+
+def interior_view(target=(0.0, 0.0, 1.4), stand=(0.0, -4.0, 1.55), lens=24.0):
+    """A camera inside a room, at eye height, on a wide lens.
+
+    Interiors are shot wide because a normal lens inside four walls sees a cupboard. 24 mm is the
+    honest default; going below 18 mm bends the verticals enough to look like an estate agent.
+    Do NOT follow this with `frame_all` — fitting every body would push the camera through a wall.
+    """
+    return camera(stand, target, lens=lens)
+
+def interior_lighting(shell, rows=2, cols=3, energy=420.0, size=1.1,
+                      colour=(1.0, 0.97, 0.92), bounce=0.35):
+    """Ceiling panels inside a room, plus a weak ambient so the corners are not holes.
+
+    A three-point rig fails indoors for a simple reason: it stands the lights where a photographer
+    would, which is outside the walls, and the walls stop the light. First attempt at a room came
+    out at mean luminance 0.025 with 52% of the frame crushed to black.
+
+    Real interiors are lit from the ceiling in a grid, and the room does the rest by bouncing. Pass
+    the dict `room()` returned. Energies are per panel and high because a ceiling panel lights a
+    floor several metres below it.
+    """
+    ambient(bounce)
+    ceiling = shell.get("ceiling") if isinstance(shell, dict) else None
+    floor = shell.get("floor") if isinstance(shell, dict) else None
+    if ceiling is None:
+        raise ValueError("interior_lighting needs the dict that room() returned")
+
+    bpy.context.view_layer.update()
+    pts = [ceiling.matrix_world @ mathutils.Vector(c) for c in ceiling.bound_box]
+    lo = mathutils.Vector((min(p.x for p in pts), min(p.y for p in pts), min(p.z for p in pts)))
+    hi = mathutils.Vector((max(p.x for p in pts), max(p.y for p in pts), max(p.z for p in pts)))
+    drop = lo.z - 0.06
+
+    made = []
+    for r in range(rows):
+        for c in range(cols):
+            fx = (c + 0.5) / cols
+            fy = (r + 0.5) / rows
+            x = lo.x + (hi.x - lo.x) * fx
+            y = lo.y + (hi.y - lo.y) * fy
+            data = bpy.data.lights.new(name=f"Panel_{r}_{c}", type="AREA")
+            data.energy = energy
+            data.size = size
+            data.color = colour
+            obj = bpy.data.objects.new(f"Panel_{r}_{c}", data)
+            obj.location = mathutils.Vector((x, y, drop))
+            bpy.context.collection.objects.link(obj)
+            obj.rotation_euler = (0.0, 0.0, 0.0)  # area lights emit along -Z by default
+            made.append(obj)
+    if floor is not None:
+        bpy.context.view_layer.update()
+    return made
+
 def studio(size=60.0, material_=None, sweep=True):
     """A ground plane large enough that its edge never enters frame, with an optional sweep.
 

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -114,8 +114,8 @@ def material(name, color, roughness=0.6, metallic=0.0):
 PALETTE = {
     "bench":    ((0.090, 0.090, 0.100), 0.80, 0.0),
     "polymer":  ((0.055, 0.055, 0.060), 0.85, 0.0),
-    "steel":    ((0.420, 0.430, 0.450), 0.30, 1.0),
-    "aluminium":((0.560, 0.570, 0.585), 0.22, 1.0),
+    "steel":    ((0.420, 0.430, 0.450), 0.18, 1.0),
+    "aluminium":((0.560, 0.570, 0.585), 0.14, 1.0),
     "floor":    ((0.300, 0.300, 0.310), 0.90, 0.0),
     "labware":  ((0.620, 0.620, 0.630), 0.45, 0.0),
     "glass":    ((0.800, 0.850, 0.860), 0.05, 0.0),
@@ -128,7 +128,7 @@ def palette():
         for name, (colour, roughness, metallic) in PALETTE.items()
     }
 
-def lab_lighting(target=(0.0, 0.0, 1.0), cam=None, key=240.0, fill=60.0, rim=36.0):
+def lab_lighting(target=(0.0, 0.0, 1.0), cam=None, key=300.0, fill=75.0, rim=45.0):
     """A three-point rig placed relative to the CAMERA, so the light always models the form.
 
     Lighting positioned in world space only works if the camera happens to be somewhere flattering.
@@ -139,6 +139,11 @@ def lab_lighting(target=(0.0, 0.0, 1.0), cam=None, key=240.0, fill=60.0, rim=36.
     So the key goes 50 degrees off the view axis and above; the fill goes to the other side at a
     quarter of the power and slightly cool; a low rim behind picks the subject off the background.
     Pass the camera returned by `camera()` or `frame_all()`. Call this AFTER framing.
+
+    The sources are large on purpose. A metal with nothing to reflect looks like paint: the legs
+    were repeatedly marked down as "painted plastic, not steel" until the lights were big enough to
+    give them a specular gradient to pick up. Big soft sources are what product photography uses on
+    metal, for exactly this reason, and the energies rise with the area.
 
     The energies are set for lights standing off at roughly the camera distance. They are higher
     than the earlier fixed-position rig because these sit further out, and light falls off with the
@@ -162,11 +167,11 @@ def lab_lighting(target=(0.0, 0.0, 1.0), cam=None, key=240.0, fill=60.0, rim=36.
             (math.cos(angle) * distance, math.sin(angle) * distance, height)
         )
 
-    k = area_light("Key", _at(50.0, reach * 0.95, reach * 1.05), target, energy=key, size=1.5)
+    k = area_light("Key", _at(50.0, reach * 0.95, reach * 1.05), target, energy=key, size=3.5)
     f = area_light("Fill", _at(-75.0, reach * 0.45, reach * 1.15), target,
-                   energy=fill, size=1.1, color=(0.84, 0.89, 1.0))
+                   energy=fill, size=2.8, color=(0.84, 0.89, 1.0))
     r = area_light("Rim", _at(165.0, reach * 0.85, reach * 0.95), target,
-                   energy=rim, size=0.8, color=(0.92, 0.94, 1.0))
+                   energy=rim, size=2.0, color=(0.92, 0.94, 1.0))
     return k, f, r
 
 def _mesh_object(name, bm, location, material_):

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -75,6 +75,19 @@ def _tolerant(func):
     def wrapper(*args, **kwargs):
         for given in list(kwargs):
             if given in names:
+                # A valid name is not the same as a valid value. `cylinder(..., segments=mat)`
+                # names a real parameter and hands it a Material, which dies inside bmesh with an
+                # error naming the wrong thing entirely. If the value cannot be what the parameter
+                # takes, it belongs somewhere else.
+                default = signature.parameters[given].default
+                mismatched = isinstance(kwargs[given], bpy.types.Material) and isinstance(
+                    default, (int, float)
+                )
+                if not mismatched:
+                    continue
+                moved = _by_type(kwargs[given], signature, kwargs)
+                if moved and moved != given:
+                    kwargs[moved] = kwargs.pop(given)
                 continue
             wanted = _ALIASES.get(given)
             if wanted not in names:

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -43,6 +43,42 @@ def material(name, color, roughness=0.6, metallic=0.0):
     bsdf.inputs["Metallic"].default_value = metallic
     return mat
 
+#: Measured, not guessed. A swatch ramp from 0.03 to 0.22 albedo was rendered against floors at
+#: 0.55, 0.30 and 0.18, and the finding was that the floor dominates: at 0.55 it bounces so much
+#: light that even a 0.03 surface reads mid-grey and no "dark" material can look dark. These values
+#: are the ones where a dark bench reads dark, steel reads metallic, and labware still reads light.
+PALETTE = {
+    "bench":    ((0.090, 0.090, 0.100), 0.80, 0.0),
+    "polymer":  ((0.055, 0.055, 0.060), 0.85, 0.0),
+    "steel":    ((0.420, 0.430, 0.450), 0.30, 1.0),
+    "aluminium":((0.560, 0.570, 0.585), 0.22, 1.0),
+    "floor":    ((0.300, 0.300, 0.310), 0.90, 0.0),
+    "labware":  ((0.620, 0.620, 0.630), 0.45, 0.0),
+    "glass":    ((0.800, 0.850, 0.860), 0.05, 0.0),
+}
+
+def palette():
+    """Every preset material, ready to use. `p = palette(); box(..., p['steel'])`."""
+    return {
+        name: material(name, colour, roughness, metallic)
+        for name, (colour, roughness, metallic) in PALETTE.items()
+    }
+
+def lab_lighting(target=(0.0, 0.0, 1.0), key=90.0, fill=22.0):
+    """A three-point rig that exposes correctly under the Standard view transform.
+
+    Energies are measured against this palette: 90 W key and 22 W fill at roughly 2.5 to 3 m give
+    a mean luminance near 0.27 with nothing blown and nothing crushed. Higher numbers were what
+    produced a frame that was 48% pure white.
+    """
+    ambient(0.06)
+    centre = mathutils.Vector(target)
+    k = area_light("Key", centre + mathutils.Vector((-1.8, -2.2, 1.9)), target,
+                   energy=key, size=1.4)
+    f = area_light("Fill", centre + mathutils.Vector((2.4, 1.2, 1.1)), target,
+                   energy=fill, size=1.0, color=(0.85, 0.90, 1.0))
+    return k, f
+
 def _mesh_object(name, bm, location, material_):
     mesh = bpy.data.meshes.new(name)
     bm.to_mesh(mesh)

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -128,13 +128,18 @@ def palette():
         for name, (colour, roughness, metallic) in PALETTE.items()
     }
 
-def lab_lighting(target=(0.0, 0.0, 1.0), cam=None, key=300.0, fill=75.0, rim=45.0):
+def lab_lighting(target=(0.0, 0.0, 1.0), cam=None, key=300.0, fill=75.0, rim=45.0,
+                 side="left"):
     """A three-point rig placed relative to the CAMERA, so the light always models the form.
 
     Lighting positioned in world space only works if the camera happens to be somewhere flattering.
     A key that lands near the camera-to-subject axis lights everything frontally, kills every
     shading gradient, and the render comes out looking like a diagram of the scene rather than a
     photograph of it. That is a real critique this rig earned, twice.
+
+    `side` decides which way the key sits as seen from the camera, so a brief asking for a
+    front-left key gets one. The rig has been marked down for lighting from the right when the
+    brief said left, which is a real note about a real photograph and not a technicality.
 
     So the key goes 50 degrees off the view axis and above; the fill goes to the other side at a
     quarter of the power and slightly cool; a low rim behind picks the subject off the background.
@@ -167,10 +172,12 @@ def lab_lighting(target=(0.0, 0.0, 1.0), cam=None, key=300.0, fill=75.0, rim=45.
             (math.cos(angle) * distance, math.sin(angle) * distance, height)
         )
 
-    k = area_light("Key", _at(50.0, reach * 0.95, reach * 1.05), target, energy=key, size=3.5)
-    f = area_light("Fill", _at(-75.0, reach * 0.45, reach * 1.15), target,
+    hand = 1.0 if str(side).lower().startswith("l") else -1.0
+    k = area_light("Key", _at(50.0 * hand, reach * 0.95, reach * 1.05), target,
+                   energy=key, size=3.5)
+    f = area_light("Fill", _at(-75.0 * hand, reach * 0.45, reach * 1.15), target,
                    energy=fill, size=2.8, color=(0.84, 0.89, 1.0))
-    r = area_light("Rim", _at(165.0, reach * 0.85, reach * 0.95), target,
+    r = area_light("Rim", _at(165.0 * hand, reach * 0.85, reach * 0.95), target,
                    energy=rim, size=2.0, color=(0.92, 0.94, 1.0))
     return k, f, r
 

--- a/scripts/scene_agent/prelude.py
+++ b/scripts/scene_agent/prelude.py
@@ -1,0 +1,110 @@
+"""Tested helpers injected ahead of every candidate script.
+
+Each function here exists because the generator got the same thing wrong more than once. Prose
+guidance did not fix any of them: telling the model that `scene.world` starts as None produced a
+script that checked `world.use_nodes` anyway, and giving it a camera-aiming recipe in words produced
+`tuple - Vector`. Working code is not misread the way a sentence is.
+
+This is the scene equivalent of a standard library. The model composes bodies out of primitives that
+are known to run, so its attention goes to arrangement, proportion and light rather than to
+rediscovering that `bmesh.ops.create_cylinder` does not exist.
+
+Injected before the candidate, so every name below is already defined when its first line runs.
+"""
+
+PRELUDE = '''
+import bmesh
+import bpy
+import mathutils
+
+def new_scene():
+    """An empty scene with a world, which an empty factory reset does not give you."""
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    scene = bpy.context.scene
+    if scene.world is None:
+        scene.world = bpy.data.worlds.new("World")
+    return scene
+
+def ambient(strength=0.1, color=(0.05, 0.05, 0.06)):
+    """Weak world light so shadows are not pure black. Keep strength between 0.05 and 0.2."""
+    world = bpy.context.scene.world
+    bg = world.node_tree.nodes.get("Background")
+    if bg is not None:
+        bg.inputs["Color"].default_value = (*color, 1.0)
+        bg.inputs["Strength"].default_value = strength
+    return world
+
+def material(name, color, roughness=0.6, metallic=0.0):
+    """A Principled material. Materials already have nodes in 5.2; `use_nodes` is deprecated."""
+    mat = bpy.data.materials.new(name)
+    bsdf = mat.node_tree.nodes["Principled BSDF"]
+    bsdf.inputs["Base Color"].default_value = (*color, 1.0)
+    bsdf.inputs["Roughness"].default_value = roughness
+    bsdf.inputs["Metallic"].default_value = metallic
+    return mat
+
+def _mesh_object(name, bm, location, material_):
+    mesh = bpy.data.meshes.new(name)
+    bm.to_mesh(mesh)
+    bm.free()
+    obj = bpy.data.objects.new(name, mesh)
+    obj.location = mathutils.Vector(location)
+    if material_ is not None:
+        obj.data.materials.append(material_)
+    bpy.context.collection.objects.link(obj)
+    return obj
+
+def box(name, size, location, material_=None):
+    """A box of the given (x, y, z) size in metres, centred on `location`."""
+    bm = bmesh.new()
+    bmesh.ops.create_cube(bm, size=1.0)
+    for vert in bm.verts:
+        vert.co.x *= size[0]
+        vert.co.y *= size[1]
+        vert.co.z *= size[2]
+    return _mesh_object(name, bm, location, material_)
+
+def cylinder(name, radius, depth, location, material_=None, segments=32):
+    """An upright cylinder. `bmesh.ops.create_cylinder` does not exist; this is create_cone."""
+    bm = bmesh.new()
+    bmesh.ops.create_cone(
+        bm, cap_ends=True, cap_tris=False, segments=segments,
+        radius1=radius, radius2=radius, depth=depth,
+    )
+    return _mesh_object(name, bm, location, material_)
+
+def plane(name, size, location=(0.0, 0.0, 0.0), material_=None):
+    """A flat square, for floors."""
+    bm = bmesh.new()
+    bmesh.ops.create_grid(bm, x_segments=1, y_segments=1, size=size / 2.0)
+    return _mesh_object(name, bm, location, material_)
+
+def aim(obj, target):
+    """Point an object's -Z at `target`. Accepts a tuple or a Vector, which is the whole point."""
+    direction = mathutils.Vector(target) - obj.location
+    obj.rotation_euler = direction.to_track_quat("-Z", "Y").to_euler()
+    return obj
+
+def camera(location, target, lens=42.0):
+    """A camera at `location` looking at `target`, set as the scene camera."""
+    data = bpy.data.cameras.new("Camera")
+    data.lens = lens
+    obj = bpy.data.objects.new("Camera", data)
+    obj.location = mathutils.Vector(location)
+    bpy.context.collection.objects.link(obj)
+    aim(obj, target)
+    bpy.context.scene.camera = obj
+    return obj
+
+def area_light(name, location, target, energy=120.0, size=1.2, color=(1.0, 0.98, 0.95)):
+    """An area light aimed at `target`. 80-150 W for a key, 20-40 W for a fill, at 2-3 m."""
+    data = bpy.data.lights.new(name=name, type="AREA")
+    data.energy = energy
+    data.size = size
+    data.color = color
+    obj = bpy.data.objects.new(name, data)
+    obj.location = mathutils.Vector(location)
+    bpy.context.collection.objects.link(obj)
+    aim(obj, target)
+    return obj
+'''

--- a/scripts/scene_agent/race.py
+++ b/scripts/scene_agent/race.py
@@ -1,0 +1,134 @@
+"""Run several independent lineages at once and keep the best one.
+
+A single refine chain is a hill climb from wherever the first attempt happened to land, and the
+first attempt is the least informed thing the model will ever produce. Running lineages in parallel
+turns that into a search: each starts from its own generation, iterates on its own critique, and the
+best surviving render wins.
+
+This is only sensible because the model is cheap. A full lineage costs a fraction of a cent, so
+eight of them cost less than one frontier-model call and finish in the time the slowest one takes
+rather than the sum. The wall clock is dominated by Blender, not by tokens, so the useful width is
+roughly the core count.
+
+The second round is where it earns its keep: the winning script is handed to every lineage as a
+starting point, with its own critique attached, so the next generation begins from the best thing
+found rather than from the brief again.
+"""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from .client import DEFAULT_MODEL
+from .loop import Attempt, run
+
+#: Beyond this the Blender processes contend and everything gets slower together.
+DEFAULT_WIDTH = 6
+
+
+def _best(attempts: list[Attempt]) -> Attempt | None:
+    """The highest-scoring attempt that actually rendered."""
+
+    scored = [a for a in attempts if a.ok and a.score is not None]
+    return max(scored, key=lambda a: a.score or 0) if scored else None
+
+
+def race(
+    brief: str,
+    out_dir: Path,
+    *,
+    lineages: int = DEFAULT_WIDTH,
+    iterations: int = 4,
+    rounds: int = 2,
+    target_score: int = 88,
+    model: str = DEFAULT_MODEL,
+    key: str | None = None,
+    width: int = 1280,
+    height: int = 720,
+    samples: int = 64,
+    engine: str = "BLENDER_EEVEE",
+) -> dict[str, Any]:
+    """Search for a scene, widthways then depthwise. Returns a summary of what was found."""
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "brief.md").write_text(brief, encoding="utf-8")
+
+    champion: Attempt | None = None
+    history: list[dict[str, Any]] = []
+    seed_note = ""
+
+    for round_index in range(1, rounds + 1):
+        round_dir = out_dir / f"round-{round_index}"
+        prompt = brief + seed_note
+
+        def one(index: int, directory: Path = round_dir, text: str = prompt) -> list[Attempt]:
+            return run(
+                text,
+                directory / f"lineage-{index}",
+                iterations=iterations,
+                target_score=target_score,
+                model=model,
+                key=key,
+                width=width,
+                height=height,
+                samples=samples,
+                engine=engine,
+            )
+
+        results: list[list[Attempt]] = []
+        with ThreadPoolExecutor(max_workers=lineages) as pool:
+            futures = {pool.submit(one, i): i for i in range(1, lineages + 1)}
+            for future in as_completed(futures):
+                try:
+                    results.append(future.result())
+                except Exception as exc:  # noqa: BLE001
+                    history.append(
+                        {"round": round_index, "lineage": futures[future], "error": str(exc)}
+                    )
+
+        for attempts in results:
+            best = _best(attempts)
+            if best is None:
+                continue
+            history.append(
+                {
+                    "round": round_index,
+                    "score": best.score,
+                    "attempts": len(attempts),
+                    "image": best.image,
+                }
+            )
+            if champion is None or (best.score or 0) > (champion.score or 0):
+                champion = best
+
+        if champion is None:
+            break
+        if (champion.score or 0) >= target_score:
+            break
+
+        seed_note = (
+            "\n\n---\nA previous attempt scored "
+            f"{champion.score}/100 and was judged: {champion.verdict}\n"
+            f"Its remaining defects were:\n{json.dumps(champion.defects, indent=1)}\n\n"
+            "Start from this script and fix those defects. Do not start over.\n"
+            f"```python\n{champion.script}\n```"
+        )
+
+    summary = {
+        "champion_score": champion.score if champion else None,
+        "champion_image": champion.image if champion else None,
+        "rounds_run": round_index if champion else 0,
+        "lineages": lineages,
+        "history": history,
+    }
+    if champion is not None:
+        (out_dir / "champion.py").write_text(champion.script, encoding="utf-8")
+        (out_dir / "champion.json").write_text(
+            json.dumps(asdict(champion) | {"script": "champion.py"}, indent=2), encoding="utf-8"
+        )
+    (out_dir / "race.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return summary

--- a/scripts/scene_agent/race.py
+++ b/scripts/scene_agent/race.py
@@ -49,8 +49,8 @@ def race(
     key: str | None = None,
     width: int = 1280,
     height: int = 720,
-    samples: int = 64,
-    engine: str = "BLENDER_EEVEE",
+    samples: int = 256,
+    engine: str = "CYCLES",
 ) -> dict[str, Any]:
     """Search for a scene, widthways then depthwise. Returns a summary of what was found."""
 

--- a/scripts/scene_agent/race.py
+++ b/scripts/scene_agent/race.py
@@ -23,7 +23,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-from .client import DEFAULT_MODEL
+from .client import GENERATOR_MODEL
 from .loop import Attempt, run
 
 #: Beyond this the Blender processes contend and everything gets slower together.
@@ -45,7 +45,7 @@ def race(
     iterations: int = 4,
     rounds: int = 2,
     target_score: int = 88,
-    model: str = DEFAULT_MODEL,
+    model: str = GENERATOR_MODEL,
     key: str | None = None,
     width: int = 1280,
     height: int = 720,

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -30,6 +30,7 @@ PROBE = f'''
 # ---- appended by scripts/scene_agent/render.py; not part of the candidate ----
 import json as _json, math as _math, sys as _sys
 import bpy as _bpy
+import mathutils as _mathutils
 
 def _finite(values):
     return all(isinstance(v, (int, float)) and _math.isfinite(v) for v in values)
@@ -107,6 +108,41 @@ for _obj in _bpy.data.objects:
         _report["defects"].append(f"object {{{{_obj.name!r}}}} has a non-finite transform")
     if _loc == (0.0, 0.0, 0.0) and _obj.type == "MESH":
         _at_origin += 1
+
+# Does the camera actually frame anything? A scene can have every object it needs, a camera and a
+# light, and still render a picture of the floor because the camera points at nothing. That reads
+# as a clean scene to every scalar check and as a failure to anyone who looks at it.
+try:
+    from bpy_extras.object_utils import world_to_camera_view as _w2c
+
+    _cam = _scene.camera
+    if _cam is not None:
+        _visible = 0
+        _considered = 0
+        for _obj in _bpy.data.objects:
+            if _obj.type != "MESH" or not _obj.data.vertices:
+                continue
+            _considered += 1
+            _corners = [_obj.matrix_world @ _mathutils.Vector(c) for c in _obj.bound_box]
+            for _corner in _corners:
+                _ndc = _w2c(_scene, _cam, _corner)
+                if 0.0 <= _ndc.x <= 1.0 and 0.0 <= _ndc.y <= 1.0 and _ndc.z > 0.0:
+                    _visible += 1
+                    break
+        _report["meshes_in_frame"] = _visible
+        _report["meshes_considered"] = _considered
+        if _considered and _visible == 0:
+            _report["defects"].append(
+                "the camera frames none of the geometry. Every mesh is outside the view or "
+                "behind the camera, so the render shows background only"
+            )
+        elif _considered >= 3 and _visible <= _considered // 4:
+            _report["defects"].append(
+                f"the camera frames only {{{{_visible}}}} of {{{{_considered}}}} meshes; most of "
+                "the scene is out of shot"
+            )
+except Exception as _exc:
+    _report["defects"].append(f"framing check failed: {{{{_exc}}}}")
 
 if _report["cameras"] == 0:
     _report["defects"].append("the scene has no camera, so nothing can be rendered")

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -318,6 +318,49 @@ if _ground_albedo is not None:
             "palette() rather than choosing a value"
         )
 
+# Detail modelled on a face the camera cannot see is the same waste as detail buried inside a
+# body: a loading slot on the back of an instrument is invisible and the housing reads as a plain
+# block. Small bodies touching a much larger one are checked against the view direction.
+if _scene.camera is not None:
+    _eye = _scene.camera.matrix_world.translation
+    _hidden = []
+    for _i in range(len(_boxes)):
+        for _j in range(len(_boxes)):
+            if _i == _j:
+                continue
+            _s, _big = _boxes[_i], _boxes[_j]
+            _vs = (_s[2] - _s[1]) * (_s[4] - _s[3]) * (_s[6] - _s[5])
+            _vb = (_big[2] - _big[1]) * (_big[4] - _big[3]) * (_big[6] - _big[5])
+            if _vb <= 0 or _vs > _vb * 0.35 or _vb > 2.0:
+                continue
+            _touch = (
+                min(_s[2], _big[2]) - max(_s[1], _big[1]) > -0.02
+                and min(_s[4], _big[4]) - max(_s[3], _big[3]) > -0.02
+                and min(_s[6], _big[6]) - max(_s[5], _big[5]) > -0.02
+            )
+            if not _touch:
+                continue
+            _cs = _mathutils.Vector(((_s[1] + _s[2]) / 2, (_s[3] + _s[4]) / 2, (_s[5] + _s[6]) / 2))
+            # A feature on a housing sits within that housing's own height. A leg sits below the
+            # bench it holds up, and is structure rather than detail, so it is not this check's
+            # business even though it is small and touching and behind.
+            if not (_big[5] - 1e-4 <= _cs.z <= _big[6] + 1e-4):
+                continue
+            _cb = _mathutils.Vector(
+                ((_big[1] + _big[2]) / 2, (_big[3] + _big[4]) / 2, (_big[5] + _big[6]) / 2)
+            )
+            _view = (_cb - _eye).normalized()
+            if (_cs - _cb).dot(_view) > 0.01:
+                _hidden.append((_s[0], _big[0]))
+            break
+    if _hidden:
+        _report["facing_away"] = [{{{{"detail": _a, "body": _b}}}} for _a, _b in _hidden[:6]]
+        _report["defects"].append(
+            "these details sit on the far side of the body they belong to and the camera cannot "
+            "see them: " + ", ".join(f"{{{{_a}}}} on {{{{_b}}}}" for _a, _b in _hidden[:4])
+            + ". Put the features on the face the camera is looking at"
+        )
+
 if _report["cameras"] == 0:
     _report["defects"].append("the scene has no camera, so nothing can be rendered")
 if _report["lights"] == 0 and _scene.render.engine != "BLENDER_WORKBENCH":

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -1,0 +1,216 @@
+"""Render a Blender script headlessly and report what came back.
+
+The agent loop needs two things from every attempt and they fail differently. The image says
+whether the scene looks like the thing it is supposed to be. The structured report says whether the
+geometry is sane, and it catches what an image cannot: an object at the origin because a transform
+silently failed, a mesh with no faces, a camera inside a wall, a NaN in a matrix.
+
+`examples/digital-twin-surrogate/scene/check_scene.py` learned the same lesson the hard way. Its
+docstring records that a scalar check "cannot see a plate that slides out of the gripper" — and the
+converse is just as true, which is why both channels run on every iteration.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: Blender writes a great deal to stdout. Only the fenced block is ours.
+PROBE_OPEN = "<<<OPENSDL-SCENE-PROBE"
+PROBE_CLOSE = "OPENSDL-SCENE-PROBE>>>"
+
+#: Appended to every candidate script. It runs after the scene is built, renders a still, and
+#: prints a structured report the loop can parse. Keeping it here rather than asking the model to
+#: emit it means the report format cannot drift between iterations.
+PROBE = f'''
+# ---- appended by scripts/scene_agent/render.py; not part of the candidate ----
+import json as _json, math as _math, sys as _sys
+import bpy as _bpy
+
+def _finite(values):
+    return all(isinstance(v, (int, float)) and _math.isfinite(v) for v in values)
+
+_scene = _bpy.context.scene
+_scene.render.filepath = {{RENDER_PATH!r}}
+_scene.render.image_settings.file_format = "PNG"
+_scene.render.resolution_x = {{WIDTH}}
+_scene.render.resolution_y = {{HEIGHT}}
+_available = {{{{item.identifier for item in
+              type(_scene.render).bl_rna.properties["engine"].enum_items}}}}
+_wanted = {{ENGINE!r}}
+_engine_note = None
+if _wanted not in _available:
+    _engine_note = f"engine {{{{_wanted!r}}}} is unavailable in this Blender; used EEVEE instead"
+    _wanted = "BLENDER_EEVEE" if "BLENDER_EEVEE" in _available else sorted(_available)[0]
+_scene.render.engine = _wanted
+if _wanted == "CYCLES":
+    _scene.cycles.samples = {{SAMPLES}}
+
+_report = {{{{"engine": _wanted, "objects": [], "cameras": 0, "lights": 0, "meshes": 0, "defects": []}}}}
+if _engine_note:
+    _report["defects"].append(_engine_note)
+_at_origin = 0
+for _obj in _bpy.data.objects:
+    _loc = tuple(_obj.location)
+    _dims = tuple(_obj.dimensions)
+    _entry = {{{{"name": _obj.name, "type": _obj.type,
+                 "location": [round(v, 4) for v in _loc],
+                 "dimensions": [round(v, 4) for v in _dims]}}}}
+    _report["objects"].append(_entry)
+    if _obj.type == "CAMERA":
+        _report["cameras"] += 1
+    elif _obj.type == "LIGHT":
+        _report["lights"] += 1
+    elif _obj.type == "MESH":
+        _report["meshes"] += 1
+        if len(_obj.data.polygons) == 0:
+            _report["defects"].append(f"mesh {{{{_obj.name!r}}}} has no faces")
+    if not _finite(_loc) or not _finite(_dims):
+        _report["defects"].append(f"object {{{{_obj.name!r}}}} has a non-finite transform")
+    if _loc == (0.0, 0.0, 0.0) and _obj.type == "MESH":
+        _at_origin += 1
+
+if _report["cameras"] == 0:
+    _report["defects"].append("the scene has no camera, so nothing can be rendered")
+if _report["lights"] == 0 and _scene.render.engine != "BLENDER_WORKBENCH":
+    _report["defects"].append("the scene has no light, so the render will be black")
+if _at_origin > 1:
+    _report["defects"].append(
+        f"{{{{_at_origin}}}} meshes sit exactly at the origin, which usually means a transform "
+        "was never applied"
+    )
+
+try:
+    _bpy.ops.render.render(write_still=True)
+    _report["rendered"] = True
+except Exception as _exc:
+    _report["rendered"] = False
+    _report["defects"].append(f"render raised {{{{type(_exc).__name__}}}}: {{{{_exc}}}}")
+
+print("{PROBE_OPEN}")
+print(_json.dumps(_report))
+print("{PROBE_CLOSE}")
+'''
+
+
+@dataclass(frozen=True)
+class RenderOutcome:
+    """Everything one attempt produced. `ok` means Blender ran, not that the scene is good."""
+
+    ok: bool
+    image: Path | None
+    report: dict[str, object] = field(default_factory=dict)
+    stderr: str = ""
+    returncode: int = 0
+
+    @property
+    def defects(self) -> list[str]:
+        found = self.report.get("defects", [])
+        return [str(item) for item in found] if isinstance(found, list) else []
+
+
+def blender_executable(explicit: str | None = None) -> str:
+    """The Blender to run, preferring an explicit path and failing loudly without one."""
+
+    found = explicit or shutil.which("blender")
+    if not found:
+        raise FileNotFoundError(
+            "blender is not on PATH. The scene agent renders headlessly and cannot work without "
+            "it. Install it, or pass --blender with a path."
+        )
+    return found
+
+
+def render_script(
+    source: str,
+    out_dir: Path,
+    *,
+    blender: str | None = None,
+    width: int = 960,
+    height: int = 540,
+    engine: str = "BLENDER_EEVEE",
+    samples: int = 64,
+    timeout: float = 300.0,
+) -> RenderOutcome:
+    """Run one candidate script in a fresh Blender and return its image and report.
+
+    The script is written to a temporary file rather than piped, so a traceback names a real line
+    number the model can act on.
+    """
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    image = out_dir / "render.png"
+    probe = PROBE.format(
+        RENDER_PATH=str(image),
+        WIDTH=width,
+        HEIGHT=height,
+        ENGINE=engine,
+        SAMPLES=samples,
+    )
+
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, encoding="utf-8") as handle:
+        handle.write(source)
+        handle.write("\n")
+        handle.write(probe)
+        script_path = Path(handle.name)
+
+    try:
+        completed = subprocess.run(  # noqa: S603
+            [blender_executable(blender), "-b", "--factory-startup", "-P", str(script_path)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return RenderOutcome(
+            ok=False,
+            image=None,
+            report={"defects": [f"blender did not finish within {timeout:.0f}s"]},
+            returncode=-1,
+        )
+    finally:
+        script_path.unlink(missing_ok=True)
+
+    report = _parse_probe(completed.stdout)
+    if report is None:
+        return RenderOutcome(
+            ok=False,
+            image=None,
+            report={"defects": ["the script failed before the probe ran"]},
+            stderr=_tail(completed.stdout + completed.stderr),
+            returncode=completed.returncode,
+        )
+
+    rendered = bool(report.get("rendered")) and image.is_file()
+    return RenderOutcome(
+        ok=rendered,
+        image=image if rendered else None,
+        report=report,
+        stderr=_tail(completed.stderr),
+        returncode=completed.returncode,
+    )
+
+
+def _parse_probe(stdout: str) -> dict[str, object] | None:
+    """Pull the fenced report out of Blender's very chatty stdout."""
+
+    if PROBE_OPEN not in stdout or PROBE_CLOSE not in stdout:
+        return None
+    body = stdout.split(PROBE_OPEN, 1)[1].split(PROBE_CLOSE, 1)[0].strip()
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _tail(text: str, lines: int = 40) -> str:
+    """The end of a traceback is the part that says what went wrong."""
+
+    kept = [line for line in text.splitlines() if line.strip()]
+    return "\n".join(kept[-lines:])

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -149,6 +149,8 @@ try:
         for _obj in _bpy.data.objects:
             if _obj.type != "MESH" or not _obj.data.vertices:
                 continue
+            if max(_obj.dimensions) > 5.0:
+                continue
             _considered += 1
             _corners = [_obj.matrix_world @ _mathutils.Vector(c) for c in _obj.bound_box]
             _inside = 0
@@ -163,9 +165,10 @@ try:
             #
             # A ground plane is the exception: it is supposed to run past the frame, and reporting
             # it every time trains the reader to ignore this defect.
+            # Scenery is meant to run past the frame; only subject matter can be "cropped".
             _dims = _obj.dimensions
-            _ground = _dims.z < 0.02 and (_dims.x > 4.0 or _dims.y > 4.0)
-            if 0 < _inside < 8 and not _ground:
+            _scenery = max(_dims) > 5.0
+            if 0 < _inside < 8 and not _scenery:
                 _cropped.append(_obj.name)
         _report["meshes_in_frame"] = _visible
         _report["meshes_considered"] = _considered
@@ -199,8 +202,7 @@ for _obj in _bpy.data.objects:
         continue
     # A ground plane is what everything else rests on, so it shares a height with every body that
     # touches it. That is a floor, not a defect.
-    _d = _obj.dimensions
-    if _d.z < 0.02 and max(_d.x, _d.y) > 4.0:
+    if max(_obj.dimensions) > 5.0:
         continue
     _pts = [_obj.matrix_world @ _mathutils.Vector(_c) for _c in _obj.bound_box]
     _boxes.append(

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -223,8 +223,13 @@ for _i in range(len(_boxes)):
             continue
         if not _overlaps(_p[3], _p[4], _q[3], _q[4]):
             continue
-        for _za in (_p[5], _p[6]):
-            for _zb in (_q[5], _q[6]):
+        # Bottom-to-bottom is not a fight. Two bodies resting on the same surface are both sunk
+        # into it by the same amount, so their undersides coincide inside a third body where
+        # nothing can see them. What fights is a top meeting a top, or a top meeting a bottom.
+        for _ia, _za in ((0, _p[5]), (1, _p[6])):
+            for _ib, _zb in ((0, _q[5]), (1, _q[6])):
+                if _ia == 0 and _ib == 0:
+                    continue
                 if abs(_za - _zb) < 5e-4:
                     _fights.append((_p[0], _q[0], round(_za, 4)))
 if _fights:

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -237,6 +237,37 @@ if _fights:
         + ". Sink one into the other by a few millimetres"
     )
 
+# A detail modelled inside a solid body renders as nothing at all. The model builds a slot or a
+# recessed panel as its own box and places it within the housing, where it is invisible and the
+# critic reports a featureless block. Containment is exact and cheap to test, so it should not need
+# an eye.
+_buried = []
+for _i in range(len(_boxes)):
+    for _j in range(len(_boxes)):
+        if _i == _j:
+            continue
+        _a, _b = _boxes[_i], _boxes[_j]
+        _inside = (
+            _a[1] >= _b[1] - 1e-5 and _a[2] <= _b[2] + 1e-5
+            and _a[3] >= _b[3] - 1e-5 and _a[4] <= _b[4] + 1e-5
+            and _a[5] >= _b[5] - 1e-5 and _a[6] <= _b[6] + 1e-5
+        )
+        _smaller = (
+            (_a[2] - _a[1]) * (_a[4] - _a[3]) * (_a[6] - _a[5])
+            < (_b[2] - _b[1]) * (_b[4] - _b[3]) * (_b[6] - _b[5]) * 0.95
+        )
+        if _inside and _smaller:
+            _buried.append((_a[0], _b[0]))
+            break
+if _buried:
+    _report["buried"] = [{{{{"inner": _a, "outer": _b}}}} for _a, _b in _buried[:8]]
+    _report["defects"].append(
+        "these bodies are entirely inside another and cannot be seen: "
+        + "; ".join(f"{{{{_a}}}} inside {{{{_b}}}}" for _a, _b in _buried[:4])
+        + ". A slot or recess has to break the outer surface: make the detail proud of the face by "
+        "1-2 mm, or model the housing as separate panels around the opening"
+    )
+
 if _report["cameras"] == 0:
     _report["defects"].append("the scene has no camera, so nothing can be rendered")
 if _report["lights"] == 0 and _scene.render.engine != "BLENDER_WORKBENCH":

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -85,6 +85,16 @@ else:
     _report_device = "CPU"
 
 
+# Blender defaults the view transform to AgX, which is built for filmic HDR footage: it
+# desaturates and lifts shadows hard. A 0.2-albedo bench under a normal key comes out of it as
+# light grey, so a scene with correct materials renders washed out and the critic blames the
+# materials. Standard is the honest transform for a technical illustration, and the harness owns
+# render settings the same way it owns resolution and engine.
+try:
+    _scene.view_settings.view_transform = "Standard"
+except Exception:
+    pass
+
 _report = {{{{"engine": _wanted, "device": _report_device, "objects": [], "cameras": 0, "lights": 0, "meshes": 0, "defects": []}}}}
 if _engine_note:
     _report["defects"].append(_engine_note)
@@ -157,6 +167,42 @@ if _at_origin > 1:
 try:
     _bpy.ops.render.render(write_still=True)
     _report["rendered"] = True
+    # What the image is actually made of. A render can be structurally perfect and still be a
+    # grey rectangle, and these three numbers say so without anyone looking.
+    try:
+        _img = _bpy.data.images.load({{RENDER_PATH!r}})
+        _px = list(_img.pixels)
+        _lum = [
+            _px[_i] * 0.2126 + _px[_i + 1] * 0.7152 + _px[_i + 2] * 0.0722
+            for _i in range(0, len(_px), 4)
+        ]
+        _n = len(_lum) or 1
+        _mean = sum(_lum) / _n
+        _blown = sum(1 for _v in _lum if _v > 0.98) / _n
+        _crushed = sum(1 for _v in _lum if _v < 0.02) / _n
+        _spread = (sum((_v - _mean) ** 2 for _v in _lum) / _n) ** 0.5
+        _report["exposure"] = {{{{
+            "mean": round(_mean, 3),
+            "blown": round(_blown, 4),
+            "crushed": round(_crushed, 4),
+            "contrast": round(_spread, 3),
+        }}}}
+        if _blown > 0.10:
+            _report["defects"].append(
+                f"{{{{_blown*100:.0f}}}}% of the image is blown to white; the key light is far too strong"
+            )
+        if _crushed > 0.25:
+            _report["defects"].append(
+                f"{{{{_crushed*100:.0f}}}}% of the image is crushed to black; there is not enough fill"
+            )
+        if _spread < 0.06:
+            _report["defects"].append(
+                f"the image has almost no tonal range (contrast {{{{_spread:.3f}}}}); it reads as a "
+                "flat field rather than as lit geometry"
+            )
+        _bpy.data.images.remove(_img)
+    except Exception as _exc:
+        _report["defects"].append(f"exposure check failed: {{{{_exc}}}}")
 except Exception as _exc:
     _report["rendered"] = False
     _report["defects"].append(f"render raised {{{{type(_exc).__name__}}}}: {{{{_exc}}}}")

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -166,7 +166,7 @@ try:
         for _obj in _bpy.data.objects:
             if _obj.type != "MESH" or not _obj.data.vertices:
                 continue
-            if max(_obj.dimensions) > 5.0:
+            if _obj.name.startswith("Shell_") or max(_obj.dimensions) > 5.0:
                 continue
             _considered += 1
             _corners = [_obj.matrix_world @ _mathutils.Vector(c) for c in _obj.bound_box]
@@ -184,7 +184,7 @@ try:
             # it every time trains the reader to ignore this defect.
             # Scenery is meant to run past the frame; only subject matter can be "cropped".
             _dims = _obj.dimensions
-            _scenery = max(_dims) > 5.0
+            _scenery = _obj.name.startswith("Shell_") or max(_dims) > 5.0
             if 0 < _inside < 8 and not _scenery:
                 _cropped.append(_obj.name)
         _report["meshes_in_frame"] = _visible
@@ -220,7 +220,7 @@ for _obj in _bpy.data.objects:
         continue
     # A ground plane is what everything else rests on, so it shares a height with every body that
     # touches it. That is a floor, not a defect.
-    if max(_obj.dimensions) > 5.0:
+    if _obj.name.startswith("Shell_") or max(_obj.dimensions) > 5.0:
         continue
     _pts = [_obj.matrix_world @ _mathutils.Vector(_c) for _c in _obj.bound_box]
     _boxes.append(
@@ -303,7 +303,9 @@ for _entry_ in _report["objects"]:
         _albedos[_entry_["name"]] = _m["albedo"]
 _ground_albedo = None
 for _obj in _bpy.data.objects:
-    if _obj.type == "MESH" and max(_obj.dimensions) > 5.0 and _obj.name in _albedos:
+    if _obj.type == "MESH" and (
+        _obj.name.startswith("Shell_") or max(_obj.dimensions) > 5.0
+    ) and _obj.name in _albedos:
         _ground_albedo = _albedos[_obj.name]
         break
 if _ground_albedo is not None:

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -97,6 +97,11 @@ try:
 except Exception:
     pass
 
+# Setting `obj.location` does not update `obj.matrix_world`; the depsgraph does, lazily. Every
+# geometry check below reads matrix_world, so without this they silently read local coordinates
+# and a bench 0.9 m up looks like it straddles the origin. This one line is load-bearing.
+_bpy.context.view_layer.update()
+
 _report = {{{{"engine": _wanted, "device": _report_device, "objects": [], "cameras": 0, "lights": 0, "meshes": 0, "defects": []}}}}
 if _engine_note:
     _report["defects"].append(_engine_note)
@@ -110,8 +115,17 @@ for _obj in _bpy.data.objects:
     _report["objects"].append(_entry)
     if _obj.type == "CAMERA":
         _report["cameras"] += 1
+        _entry["lens"] = round(_obj.data.lens, 1)
     elif _obj.type == "LIGHT":
         _report["lights"] += 1
+        # The critic asked for these by name: without energy and size it cannot tell an
+        # underexposed scene from a correctly lit one that needs a stronger key.
+        _entry["light"] = {{{{
+            "type": _obj.data.type,
+            "energy": round(_obj.data.energy, 1),
+            "size": round(getattr(_obj.data, "size", 0.0), 3),
+            "color": [round(_c, 3) for _c in _obj.data.color],
+        }}}}
     elif _obj.type == "MESH":
         _report["meshes"] += 1
         if len(_obj.data.polygons) == 0:
@@ -131,18 +145,37 @@ try:
     if _cam is not None:
         _visible = 0
         _considered = 0
+        _cropped = []
         for _obj in _bpy.data.objects:
             if _obj.type != "MESH" or not _obj.data.vertices:
                 continue
             _considered += 1
             _corners = [_obj.matrix_world @ _mathutils.Vector(c) for c in _obj.bound_box]
+            _inside = 0
             for _corner in _corners:
                 _ndc = _w2c(_scene, _cam, _corner)
                 if 0.0 <= _ndc.x <= 1.0 and 0.0 <= _ndc.y <= 1.0 and _ndc.z > 0.0:
-                    _visible += 1
-                    break
+                    _inside += 1
+            if _inside:
+                _visible += 1
+            # Partly in shot is its own failure. A leg whose foot is cut off satisfies any check
+            # that asks "is this object visible" and still breaks the composition.
+            #
+            # A ground plane is the exception: it is supposed to run past the frame, and reporting
+            # it every time trains the reader to ignore this defect.
+            _dims = _obj.dimensions
+            _ground = _dims.z < 0.02 and (_dims.x > 4.0 or _dims.y > 4.0)
+            if 0 < _inside < 8 and not _ground:
+                _cropped.append(_obj.name)
         _report["meshes_in_frame"] = _visible
         _report["meshes_considered"] = _considered
+        if _cropped:
+            _report["cropped"] = _cropped
+            _report["defects"].append(
+                "these bodies are cut off by the frame edge: "
+                + ", ".join(_cropped[:6])
+                + ". Pull the camera back or raise the lens until each one is whole"
+            )
         if _considered and _visible == 0:
             _report["defects"].append(
                 "the camera frames none of the geometry. Every mesh is outside the view or "
@@ -155,6 +188,37 @@ try:
             )
 except Exception as _exc:
     _report["defects"].append(f"framing check failed: {{{{_exc}}}}")
+
+# Two bodies whose faces sit at exactly the same height fight for the same pixels. It shows up as
+# flickering squares and it is a modelling mistake, not a render setting: a leg that reaches the
+# top of a bench rather than the underside of it.
+_planes = {{{{}}}}
+for _obj in _bpy.data.objects:
+    if _obj.type != "MESH" or not _obj.data.vertices:
+        continue
+    _zs = [(_obj.matrix_world @ _mathutils.Vector(_c)).z for _c in _obj.bound_box]
+    for _z in (round(min(_zs), 4), round(max(_zs), 4)):
+        _planes.setdefault(_z, []).append(_obj.name)
+import re as _re
+
+def _family(_name):
+    """Leg0 and Leg1 are the same kind of body. Four identical legs sharing a height is not a bug."""
+    return _re.sub(r"[._]?\d+$", "", _name)
+
+for _z, _names in _planes.items():
+    _families = sorted({{{{_family(_n) for _n in _names}}}})
+    if len(_families) >= 2:
+        _report.setdefault("coplanar", []).append(
+            {{{{"z": _z, "objects": sorted(set(_names))[:6], "families": _families}}}}
+        )
+_coplanar = _report.get("coplanar") or []
+_suspect = [_c for _c in _coplanar if _c["z"] != 0.0]
+if _suspect:
+    _report["defects"].append(
+        "surfaces share an exact height and will z-fight: "
+        + "; ".join(f"z={{{{_c['z']}}}} {{{{', '.join(_c['objects'][:3])}}}}" for _c in _suspect[:3])
+        + ". Overlap the bodies or offset them by a millimetre"
+    )
 
 if _report["cameras"] == 0:
     _report["defects"].append("the scene has no camera, so nothing can be rendered")

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -194,7 +194,8 @@ try:
             _report["defects"].append(
                 "these bodies are cut off by the frame edge: "
                 + ", ".join(_cropped[:6])
-                + ". Pull the camera back or raise the lens until each one is whole"
+                + ". Call frame_all(cam) after building, or frame_all(cam, distance=D) to hold "
+        "a distance and solve the lens"
             )
         if _considered and _visible == 0:
             _report["defects"].append(
@@ -258,7 +259,8 @@ if _fights:
     _report["defects"].append(
         "these bodies overlap in plan and share an exact height, so they will z-fight: "
         + "; ".join(f"{{{{_a}}}}/{{{{_b}}}} at z={{{{_z}}}}" for _a, _b, _z in _fights[:3])
-        + ". Sink one into the other by a few millimetres"
+        + ". Use on_surface(name, size, xy, the_body_below) to stack, or bench() for a bench: "
+        "both sink the joint for you"
     )
 
 # A detail modelled inside a solid body renders as nothing at all. The model builds a slot or a
@@ -288,8 +290,8 @@ if _buried:
     _report["defects"].append(
         "these bodies are entirely inside another and cannot be seen: "
         + "; ".join(f"{{{{_a}}}} inside {{{{_b}}}}" for _a, _b in _buried[:4])
-        + ". A slot or recess has to break the outer surface: make the detail proud of the face by "
-        "1-2 mm, or model the housing as separate panels around the opening"
+        + ". Use face_detail(name, parent, size, where='camera') — it puts the feature on a "
+        "visible face, standing proud of it, and cannot bury it"
     )
 
 # Contrast between the subject and what it stands on is a material decision, not a lighting one,
@@ -358,7 +360,7 @@ if _scene.camera is not None:
         _report["defects"].append(
             "these details sit on the far side of the body they belong to and the camera cannot "
             "see them: " + ", ".join(f"{{{{_a}}}} on {{{{_b}}}}" for _a, _b in _hidden[:4])
-            + ". Put the features on the face the camera is looking at"
+            + ". Use face_detail(..., where='camera'), which picks the visible face itself"
         )
 
 if _report["cameras"] == 0:

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -19,6 +19,8 @@ import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from .prelude import PRELUDE
+
 #: Blender writes a great deal to stdout. Only the fenced block is ours.
 PROBE_OPEN = "<<<OPENSDL-SCENE-PROBE"
 PROBE_CLOSE = "OPENSDL-SCENE-PROBE>>>"
@@ -269,6 +271,8 @@ def render_script(
     )
 
     with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, encoding="utf-8") as handle:
+        handle.write(PRELUDE)
+        handle.write("\n")
         handle.write(source)
         handle.write("\n")
         handle.write(probe)

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -189,35 +189,52 @@ try:
 except Exception as _exc:
     _report["defects"].append(f"framing check failed: {{{{_exc}}}}")
 
-# Two bodies whose faces sit at exactly the same height fight for the same pixels. It shows up as
-# flickering squares and it is a modelling mistake, not a render setting: a leg that reaches the
-# top of a bench rather than the underside of it.
-_planes = {{{{}}}}
+# Two bodies whose faces sit at the same height AND overlap in plan will fight for the same
+# pixels. Both conditions matter: four legs at one corner height each are a bench, not a bug, and
+# only the pair that also overlaps in x and y can actually z-fight. Testing the geometry rather
+# than the names avoids guessing which of Leg_BL and Leg_FR are siblings.
+_boxes = []
 for _obj in _bpy.data.objects:
     if _obj.type != "MESH" or not _obj.data.vertices:
         continue
-    _zs = [(_obj.matrix_world @ _mathutils.Vector(_c)).z for _c in _obj.bound_box]
-    for _z in (round(min(_zs), 4), round(max(_zs), 4)):
-        _planes.setdefault(_z, []).append(_obj.name)
-import re as _re
-
-def _family(_name):
-    """Leg0 and Leg1 are the same kind of body. Four identical legs sharing a height is not a bug."""
-    return _re.sub(r"[._]?\d+$", "", _name)
-
-for _z, _names in _planes.items():
-    _families = sorted({{{{_family(_n) for _n in _names}}}})
-    if len(_families) >= 2:
-        _report.setdefault("coplanar", []).append(
-            {{{{"z": _z, "objects": sorted(set(_names))[:6], "families": _families}}}}
+    # A ground plane is what everything else rests on, so it shares a height with every body that
+    # touches it. That is a floor, not a defect.
+    _d = _obj.dimensions
+    if _d.z < 0.02 and max(_d.x, _d.y) > 4.0:
+        continue
+    _pts = [_obj.matrix_world @ _mathutils.Vector(_c) for _c in _obj.bound_box]
+    _boxes.append(
+        (
+            _obj.name,
+            min(_p.x for _p in _pts), max(_p.x for _p in _pts),
+            min(_p.y for _p in _pts), max(_p.y for _p in _pts),
+            min(_p.z for _p in _pts), max(_p.z for _p in _pts),
         )
-_coplanar = _report.get("coplanar") or []
-_suspect = [_c for _c in _coplanar if _c["z"] != 0.0]
-if _suspect:
+    )
+
+def _overlaps(_a, _b, _c, _d):
+    return min(_b, _d) - max(_a, _c) > 1e-4
+
+_fights = []
+for _i in range(len(_boxes)):
+    for _j in range(_i + 1, len(_boxes)):
+        _p, _q = _boxes[_i], _boxes[_j]
+        if not _overlaps(_p[1], _p[2], _q[1], _q[2]):
+            continue
+        if not _overlaps(_p[3], _p[4], _q[3], _q[4]):
+            continue
+        for _za in (_p[5], _p[6]):
+            for _zb in (_q[5], _q[6]):
+                if abs(_za - _zb) < 5e-4:
+                    _fights.append((_p[0], _q[0], round(_za, 4)))
+if _fights:
+    _report["coplanar"] = [
+        {{{{"a": _a, "b": _b, "z": _z}}}} for _a, _b, _z in _fights[:8]
+    ]
     _report["defects"].append(
-        "surfaces share an exact height and will z-fight: "
-        + "; ".join(f"z={{{{_c['z']}}}} {{{{', '.join(_c['objects'][:3])}}}}" for _c in _suspect[:3])
-        + ". Overlap the bodies or offset them by a millimetre"
+        "these bodies overlap in plan and share an exact height, so they will z-fight: "
+        + "; ".join(f"{{{{_a}}}}/{{{{_b}}}} at z={{{{_z}}}}" for _a, _b, _z in _fights[:3])
+        + ". Sink one into the other by a few millimetres"
     )
 
 if _report["cameras"] == 0:

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -39,18 +39,52 @@ _scene.render.filepath = {{RENDER_PATH!r}}
 _scene.render.image_settings.file_format = "PNG"
 _scene.render.resolution_x = {{WIDTH}}
 _scene.render.resolution_y = {{HEIGHT}}
-_available = {{{{item.identifier for item in
-              type(_scene.render).bl_rna.properties["engine"].enum_items}}}}
+# Cycles registers itself as a plugin, so it never appears in the class-level RNA enum even
+# when it is installed and working. Introspecting `enum_items` reports a false negative; the
+# only honest test is to assign and see whether it takes.
 _wanted = {{ENGINE!r}}
 _engine_note = None
-if _wanted not in _available:
+try:
+    _scene.render.engine = _wanted
+except TypeError:
     _engine_note = f"engine {{{{_wanted!r}}}} is unavailable in this Blender; used EEVEE instead"
-    _wanted = "BLENDER_EEVEE" if "BLENDER_EEVEE" in _available else sorted(_available)[0]
+    _wanted = "BLENDER_EEVEE"
 _scene.render.engine = _wanted
 if _wanted == "CYCLES":
     _scene.cycles.samples = {{SAMPLES}}
+    # OptiX first, CUDA second, CPU last. Hardware ray tracing plus OptiX denoising gives a clean
+    # image at sample counts where an undenoised render would still be visibly grainy, which is
+    # the difference between a usable critique and one arguing about noise.
+    _prefs = _bpy.context.preferences.addons["cycles"].preferences
+    _chosen = None
+    for _backend in ("OPTIX", "CUDA"):
+        try:
+            _prefs.compute_device_type = _backend
+            _prefs.refresh_devices()
+        except Exception:
+            continue
+        _gpus = [_d for _d in _prefs.devices if _d.type == _backend]
+        if _gpus:
+            for _d in _prefs.devices:
+                _d.use = _d.type == _backend
+            _chosen = _backend
+            break
+    if _chosen:
+        _scene.cycles.device = "GPU"
+        _report_device = f"{{{{_chosen}}}}:{{{{_gpus[0].name}}}}"
+    else:
+        _scene.cycles.device = "CPU"
+        _report_device = "CPU"
+    try:
+        _scene.cycles.use_denoising = True
+        _scene.cycles.denoiser = "OPTIX" if _chosen == "OPTIX" else "OPENIMAGEDENOISE"
+    except Exception:
+        pass
+else:
+    _report_device = "CPU"
 
-_report = {{{{"engine": _wanted, "objects": [], "cameras": 0, "lights": 0, "meshes": 0, "defects": []}}}}
+
+_report = {{{{"engine": _wanted, "device": _report_device, "objects": [], "cameras": 0, "lights": 0, "meshes": 0, "defects": []}}}}
 if _engine_note:
     _report["defects"].append(_engine_note)
 _at_origin = 0
@@ -132,9 +166,9 @@ def render_script(
     blender: str | None = None,
     width: int = 960,
     height: int = 540,
-    engine: str = "BLENDER_EEVEE",
-    samples: int = 64,
-    timeout: float = 300.0,
+    engine: str = "CYCLES",
+    samples: int = 256,
+    timeout: float = 420.0,
 ) -> RenderOutcome:
     """Run one candidate script in a fresh Blender and return its image and report.
 
@@ -160,7 +194,11 @@ def render_script(
 
     try:
         completed = subprocess.run(  # noqa: S603
-            [blender_executable(blender), "-b", "--factory-startup", "-P", str(script_path)],
+            # No `--factory-startup`: it disables addons, and Cycles never returns to the engine
+            # enum even after `addon_enable`, so the GPU path becomes unreachable. Scene-level
+            # determinism comes from the candidate calling `read_factory_settings(use_empty=True)`,
+            # which resets the scene without resetting preferences.
+            [blender_executable(blender), "-b", "-P", str(script_path)],
             capture_output=True,
             text=True,
             timeout=timeout,

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -278,6 +278,15 @@ try:
             _report["defects"].append(
                 f"{{{{_crushed*100:.0f}}}}% of the image is crushed to black; there is not enough fill"
             )
+        if _mean < 0.14:
+            _report["defects"].append(
+                f"the image is underexposed (mean luminance {{{{_mean:.3f}}}}); raise the key light "
+                "or move it closer"
+            )
+        if _mean > 0.72:
+            _report["defects"].append(
+                f"the image is overexposed (mean luminance {{{{_mean:.3f}}}}); lower the key light"
+            )
         if _spread < 0.06:
             _report["defects"].append(
                 f"the image has almost no tonal range (contrast {{{{_spread:.3f}}}}); it reads as a "

--- a/scripts/scene_agent/render.py
+++ b/scripts/scene_agent/render.py
@@ -113,6 +113,23 @@ for _obj in _bpy.data.objects:
                  "location": [round(v, 4) for v in _loc],
                  "dimensions": [round(v, 4) for v in _dims]}}}}
     _report["objects"].append(_entry)
+    if _obj.type == "MESH" and _obj.data.materials:
+        # What the surface actually is, so a critique of how it looks can be checked against it.
+        # The recurring note has been "reads mid-grey, not the dark grey specified", and without
+        # this nobody can tell whether the material is wrong or the light is.
+        _mat = _obj.data.materials[0]
+        try:
+            _bsdf = _mat.node_tree.nodes["Principled BSDF"]
+            _base = _bsdf.inputs["Base Color"].default_value
+            _entry["material"] = {{{{
+                "name": _mat.name,
+                "albedo": round(sum(_base[:3]) / 3.0, 3),
+                "roughness": round(_bsdf.inputs["Roughness"].default_value, 2),
+                "metallic": round(_bsdf.inputs["Metallic"].default_value, 2),
+            }}}}
+        except Exception:
+            pass
+
     if _obj.type == "CAMERA":
         _report["cameras"] += 1
         _entry["lens"] = round(_obj.data.lens, 1)
@@ -274,6 +291,32 @@ if _buried:
         + ". A slot or recess has to break the outer surface: make the detail proud of the face by "
         "1-2 mm, or model the housing as separate panels around the opening"
     )
+
+# Contrast between the subject and what it stands on is a material decision, not a lighting one,
+# and it is the note this build has drawn most often.
+_albedos = {{{{}}}}
+for _entry_ in _report["objects"]:
+    _m = _entry_.get("material")
+    if _m:
+        _albedos[_entry_["name"]] = _m["albedo"]
+_ground_albedo = None
+for _obj in _bpy.data.objects:
+    if _obj.type == "MESH" and max(_obj.dimensions) > 5.0 and _obj.name in _albedos:
+        _ground_albedo = _albedos[_obj.name]
+        break
+if _ground_albedo is not None:
+    _too_close = [
+        _n for _n, _a in _albedos.items()
+        if _n not in ("Floor", "Backdrop")
+        and abs(_a - _ground_albedo) < 0.06
+        and _n in [_o.name for _o in _bpy.data.objects if max(_o.dimensions) <= 5.0]
+    ]
+    if _too_close:
+        _report["defects"].append(
+            f"these surfaces sit within 0.06 albedo of the ground ({{{{_ground_albedo}}}}) and will "
+            f"not read as distinct from it: {{{{', '.join(_too_close[:4])}}}}. Take the material from "
+            "palette() rather than choosing a value"
+        )
 
 if _report["cameras"] == 0:
     _report["defects"].append("the scene has no camera, so nothing can be rendered")

--- a/scripts/scene_agent/scenes/__init__.py
+++ b/scripts/scene_agent/scenes/__init__.py
@@ -1,0 +1,1 @@
+"""Scene sources kept under version control, so a render is reproducible from the repository."""

--- a/scripts/scene_agent/scenes/facility_hall.py
+++ b/scripts/scene_agent/scenes/facility_hall.py
@@ -1,0 +1,153 @@
+"""A facility-scale laboratory hall, as scene-agent source.
+
+This is the reference the library was built against: a 13 x 22 x 4 m hall holding a synthesis line
+of seven fume hoods, a gantry with three arms over four workbenches of plate hotels, five
+characterisation bays, a consumables run under a glazed wall, a control station, and a transport
+robot on a marked lane. 448 mesh nodes.
+
+It exists for two reasons. It is the standing regression case for `prelude.py`, because every helper
+that room-scale work needed was found by rendering this and looking at it. And it is the shape a
+facility-scale twin arrives in: `export_scene` turns it into GLB plus digest plus a draft
+`twin.yaml` that `opensdl twin validate` accepts, which is the handoff D14 requires and the one that
+has to work before any domain-specific buildout is worth starting.
+
+The camera is deliberate rather than fitted. `frame_all` would retreat outside the room to see the
+whole hall; an establishing shot from inside it wants the near four metres of floor empty, which is
+a composition decision the framing check cannot make.
+"""
+
+from __future__ import annotations
+
+#: The scene, as a script for `render_script` or `export_scene`. Both inject `prelude.PRELUDE`
+#: ahead of it, so every helper called here is defined there.
+SOURCE = r"""
+scene = new_scene(); p = palette()
+floor = tiled('floor', colour=(0.42,0.41,0.40), grout=(0.30,0.295,0.29), tile=0.60)
+wall  = material('wall', (0.55,0.555,0.565), 0.80)
+ceil  = material('ceil', (0.58,0.58,0.59), 0.85)
+st    = material('steel', (0.52,0.53,0.55), 0.16, 1.0)
+al    = material('alu',   (0.50,0.51,0.525), 0.34, 1.0)
+dark  = material('dark',  (0.085,0.085,0.095), 0.55)
+glass = material('glass', (0.62,0.70,0.72), 0.06)
+amber = material('amber', (0.85,0.52,0.10), 0.45)
+sig   = material('signal',(0.15,0.55,0.35), 0.40)
+warn  = material('warn',  (0.72,0.16,0.14), 0.45)
+
+W, D, H = 13.0, 22.0, 4.0
+shell = room(width=W, depth=D, height=H, floor_material=floor, wall_material=wall,
+             ceiling_material=ceil, open_side='front', glazed='right')
+LX, RX = -W/2 + 0.55, W/2 - 0.50
+
+# ---------------------------------------------------------------- synthesis line, left wall
+for i in range(7):
+    y = -5.6 + i*2.55
+    box('Hood%d_Body' % i, (1.05, 2.30, 2.55), (LX, y, 1.28), al)
+    box('Hood%d_Void' % i, (0.80, 2.05, 1.05), (LX+0.16, y, 1.42), dark)
+    box('Hood%d_Sash' % i, (0.05, 2.05, 0.72), (LX+0.53, y, 1.80), glass)
+    box('Hood%d_Deck' % i, (0.86, 2.10, 0.05), (LX+0.14, y, 0.885), st)
+    box('Hood%d_Panel'% i, (0.05, 0.52, 0.26), (LX+0.55, y-0.72, 1.06), dark)
+    box('Hood%d_Lamp' % i, (0.04, 0.10, 0.08), (LX+0.57, y-0.86, 1.06), sig)
+    box('Hood%d_Duct' % i, (0.34, 0.34, 1.45), (LX, y, 3.28), al)
+box('DuctSpine', (0.42, 18.6, 0.42), (LX, 1.9, 3.86), al)
+
+# ---------------------------------------------------------------- robot aisle, left of centre
+box('RailBeam', (0.30, 14.0, 0.22), (-2.55, 2.4, 1.30), al)
+for i in range(4):
+    y = -4.0 + i*4.0
+    box('RailPost%d' % i, (0.22, 0.22, 1.20), (-2.55, y, 0.60), al)
+for a in range(3):
+    y = -3.2 + a*4.6
+    box('Arm%d_Base'  % a, (0.40, 0.40, 0.22), (-2.55, y, 1.52), dark)
+    cylinder('Arm%d_Turret' % a, 0.17, 0.28, (-2.55, y, 1.75), amber)
+    box('Arm%d_Shoulder'%a,(0.24, 0.24, 0.20), (-2.55, y, 1.99), dark)
+    box('Arm%d_Link1' % a, (0.15, 0.15, 0.80), (-2.42, y, 2.45), amber)
+    box('Arm%d_Elbow' % a, (0.19, 0.19, 0.19), (-2.42, y, 2.88), dark)
+    box('Arm%d_Link2' % a, (0.13, 0.78, 0.13), (-2.42, y+0.44, 2.88), amber)
+    box('Arm%d_Wrist' % a, (0.15, 0.15, 0.16), (-2.42, y+0.86, 2.86), dark)
+    box('Arm%d_Grip'  % a, (0.05, 0.05, 0.20), (-2.42, y+0.86, 2.70), st)
+    box('Arm%d_Jaw'   % a, (0.11, 0.03, 0.10), (-2.42, y+0.86, 2.57), st)
+
+# workbenches under the rail, each carrying plate hotels
+for b in range(4):
+    y = -4.2 + b*4.0
+    box('Bench%d_Top' % b, (1.55, 2.90, 0.06), (-1.30, y, 0.90), st)
+    box('Bench%d_Skirt'%b, (1.42, 2.78, 0.62), (-1.30, y, 0.55), al)
+    for L in range(6):
+        box('Hotel%d_%d' % (b,L), (1.02, 0.62, 0.035), (-1.30, y+1.05, 1.03 + L*0.30), st)
+        box('Plate%d_%d' % (b,L), (0.86, 0.52, 0.075), (-1.30, y+1.05, 1.085 + L*0.30),
+            [p['labware'], p['crate'], p['glass']][L % 3])
+    box('Bench%d_Frame'%b, (0.05, 0.05, 1.90), (-1.81, y+1.05, 1.85), al)
+    box('Bench%d_Frame2'%b,(0.05, 0.05, 1.90), (-0.79, y+1.05, 1.85), al)
+
+# ---------------------------------------------------------------- characterisation line, right of centre
+NAMES = ('XRD', 'Raman', 'SEM', 'DSC', 'GC')
+for i, nm in enumerate(NAMES):
+    y = -0.6 + i*4.15
+    box('%s_Cab' % nm,   (1.45, 2.45, 2.05), (2.15, y, 1.03), al)
+    box('%s_Face' % nm,  (0.06, 2.05, 1.50), (1.44, y, 1.28), dark)
+    box('%s_Door' % nm,  (0.05, 0.95, 0.88), (1.40, y-0.38, 1.26), glass)
+    box('%s_Screen' % nm,(0.05, 0.58, 0.38), (1.39, y+0.66, 1.64), sig)
+    box('%s_Vent' % nm,  (1.20, 0.55, 0.22), (2.15, y, 2.19), al)
+    box('%s_Rear' % nm,  (0.05, 2.05, 1.60), (2.86, y, 1.20), dark)
+    for g in range(5):
+        box('%s_Fin%d' % (nm,g), (0.06, 1.70, 0.07), (2.89, y, 0.62 + g*0.30), al)
+    box('%s_Cond' % nm,  (0.10, 0.10, 1.95), (2.94, y+1.15, 1.00), al)
+    box('%s_Foot' % nm,  (1.50, 2.50, 0.09), (2.15, y, 0.045), dark)
+    box('%s_Front' % nm, (1.30, 0.05, 1.35), (2.15, y-1.24, 1.20), dark)
+    box('%s_Band' % nm,  (1.36, 0.05, 0.20), (2.15, y-1.26, 1.98), amber)
+    box('%s_Grille'% nm, (1.05, 0.05, 0.42), (2.15, y-1.26, 0.42), al)
+    for k in range(3):
+        box('%s_Led%d' % (nm,k), (0.04, 0.07, 0.07), (1.38, y+0.56, 1.08 - k*0.14),
+            [sig, amber, warn][k])
+
+# ---------------------------------------------------------------- consumables run, under the glazing
+box('RTop', (0.85, 15.0, 0.06), (RX, 1.4, 0.92), st)
+for i in range(12):
+    box('RCab%d' % i, (0.78, 1.36, 0.84), (RX, -5.6 + i*1.42, 0.44), al)
+    box('RHandle%d'%i, (0.03, 0.72, 0.035), (RX-0.42, -5.6 + i*1.42, 0.70), dark)
+for j in range(16):
+    m = [p['crate'], p['labware'], p['timber'], p['copper'], p['glass']][j % 5]
+    box('RBox%d' % j, (0.50, 0.60, 0.30), (RX-0.04, -5.4 + j*1.06, 1.10), m)
+
+# ---------------------------------------------------------------- control station, far wall
+box('RackA', (1.05, 1.00, 2.20), (-3.4, D/2-0.85, 1.10), dark)
+box('RackB', (1.05, 1.00, 2.20), (-2.25, D/2-0.85, 1.10), dark)
+for r in range(11):
+    box('RackA_U%d' % r, (0.95, 0.05, 0.13), (-3.4, D/2-1.37, 0.30 + r*0.17), al)
+    box('RackB_U%d' % r, (0.95, 0.05, 0.13), (-2.25, D/2-1.37, 0.30 + r*0.17), al)
+    box('RackA_L%d' % r, (0.06, 0.03, 0.04), (-3.78, D/2-1.40, 0.30 + r*0.17), sig)
+    box('RackB_L%d' % r, (0.06, 0.03, 0.04), (-2.63, D/2-1.40, 0.30 + r*0.17), amber)
+box('DeskTop', (4.6, 0.85, 0.06), (0.6, D/2-0.70, 0.76), st)
+for i, x in enumerate((-1.5, 0.6, 2.7)):
+    box('Mon%d' % i, (1.05, 0.05, 0.60), (x, D/2-0.42, 1.15), dark)
+    box('MonFace%d' % i, (0.98, 0.03, 0.54), (x, D/2-0.455, 1.15), sig)
+    box('MonStand%d' % i, (0.14, 0.14, 0.24), (x, D/2-0.44, 0.91), al)
+
+# ---------------------------------------------------------------- transport robot in the aisle
+box('AMR_Body', (0.86, 1.24, 0.34), (0.15, -1.4, 0.28), amber)
+box('AMR_Deck', (0.94, 1.30, 0.05), (0.15, -1.4, 0.47), st)
+box('AMR_Load', (0.62, 0.78, 0.42), (0.15, -1.4, 0.71), p['crate'])
+for w in ((-0.36,-0.44),(0.36,-0.44),(-0.36,0.44),(0.36,0.44)):
+    cylinder('AMR_W%s%s' % w, 0.11, 0.09, (0.15+w[0], -1.4+w[1], 0.11), dark)
+box('AMR_Mast', (0.07, 0.07, 0.60), (0.15, -1.94, 0.78), al)
+box('AMR_Beacon', (0.10, 0.10, 0.09), (0.15, -1.94, 1.12), sig)
+
+# ---------------------------------------------------------------- floor markings for the transport lane
+lane = material('lane', (0.72, 0.58, 0.10), 0.75)
+for s in range(22):
+    box('Lane_L%d' % s, (0.09, 0.62, 0.006), (-0.62, -8.4 + s*0.86, 0.004), lane)
+    box('Lane_R%d' % s, (0.09, 0.62, 0.006), ( 0.92, -8.4 + s*0.86, 0.004), lane)
+
+box('Tray_Spine', (0.30, 19.0, 0.08), (-0.30, 1.4, 3.88), al)
+for t in range(13):
+    box('Tray_Hanger%d' % t, (0.05, 0.05, 0.16), (-0.30, -7.4 + t*1.55, 3.94), al)
+    box('Tray_Cond%d' % t,   (0.05, 19.0, 0.05), (-0.40 + (t%5)*0.05, 1.4, 3.82), dark)
+for f in range(9):
+    box('Fixture%d_A' % f, (1.30, 0.30, 0.10), (-3.9, -7.0 + f*2.1, 3.90), al)
+    box('Fixture%d_B' % f, (1.30, 0.30, 0.10), ( 3.3, -7.0 + f*2.1, 3.90), al)
+
+outside(shell, side='right', distance=9.0, brightness=3.0)
+cam = interior_view(target=(0.15, 7.0, 1.45), stand=(-0.10, -10.5, 2.05), lens=26.0)
+interior_lighting(shell, rows=6, cols=3, energy=23)
+daylight(direction=(-0.82, 0.30, -0.50), energy=4.6)
+"""

--- a/scripts/scene_agent/sheet.py
+++ b/scripts/scene_agent/sheet.py
@@ -1,0 +1,119 @@
+"""Write the run as one page: every attempt, its render, and what the critic said about it.
+
+A score in a log tells you the loop converged. It does not tell you *how*, and it does not let
+anybody else check the critic's judgement against the image it was judging. This page puts the
+render, the score, the defects and the next actions side by side for every iteration, so the
+progression is legible without opening seven directories.
+
+Plain HTML with inlined images and no dependencies, because the point is that it opens.
+"""
+
+from __future__ import annotations
+
+import base64
+import html
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+CSS = """
+:root { --bg:#faf9f7; --ink:#1a1a1a; --dim:#6b6b6b; --line:#e2ded9; --bad:#a33; --good:#2c6e49; }
+* { box-sizing: border-box; }
+body { margin:0; padding:2rem; background:var(--bg); color:var(--ink);
+       font:15px/1.55 ui-sans-serif,-apple-system,"Segoe UI",sans-serif; }
+h1 { font-size:1.4rem; margin:0 0 .25rem; letter-spacing:-.01em; }
+.sub { color:var(--dim); margin:0 0 2rem; font-size:.9rem; }
+.brief { background:#fff; border:1px solid var(--line); border-radius:6px; padding:1rem 1.25rem;
+         margin-bottom:2rem; white-space:pre-wrap; font-size:.9rem; }
+.step { display:grid; grid-template-columns:minmax(0,1.15fr) minmax(0,1fr); gap:1.5rem;
+        background:#fff; border:1px solid var(--line); border-radius:6px; padding:1.25rem;
+        margin-bottom:1.25rem; }
+@media (max-width:900px){ .step { grid-template-columns:1fr; } }
+.step img { width:100%; height:auto; border-radius:4px; border:1px solid var(--line);
+            background:#111; display:block; }
+.none { padding:3rem 1rem; text-align:center; color:var(--bad); border:1px dashed var(--bad);
+        border-radius:4px; font-size:.9rem; }
+.head { display:flex; align-items:baseline; gap:.75rem; margin-bottom:.5rem; }
+.n { font-weight:600; }
+.score { font-variant-numeric:tabular-nums; font-weight:600; }
+.score.hi { color:var(--good); } .score.lo { color:var(--bad); }
+.verdict { margin:.25rem 0 .9rem; }
+h3 { font-size:.72rem; text-transform:uppercase; letter-spacing:.07em; color:var(--dim);
+     margin:1rem 0 .35rem; }
+ul { margin:0; padding-left:1.1rem; } li { margin-bottom:.3rem; font-size:.88rem; }
+li.probe { color:var(--bad); }
+pre { background:#f4f2ef; border:1px solid var(--line); border-radius:4px; padding:.6rem .8rem;
+      overflow-x:auto; font-size:.78rem; margin:.3rem 0 0; }
+footer { color:var(--dim); font-size:.85rem; margin-top:2rem; border-top:1px solid var(--line);
+         padding-top:1rem; }
+"""
+
+
+def _img(path: str | None) -> str:
+    """Inline the render so the page is one self-contained file."""
+
+    if not path:
+        return '<div class="none">nothing rendered</div>'
+    source = Path(path)
+    if not source.is_file():
+        return '<div class="none">render missing</div>'
+    encoded = base64.b64encode(source.read_bytes()).decode("ascii")
+    return f'<img alt="render" src="data:image/png;base64,{encoded}">'
+
+
+def _items(values: list[str], css: str = "") -> str:
+    if not values:
+        return '<p style="color:var(--dim);font-size:.88rem;margin:.2rem 0">none</p>'
+    cls = f' class="{css}"' if css else ""
+    return "<ul>" + "".join(f"<li{cls}>{html.escape(v)}</li>" for v in values) + "</ul>"
+
+
+def write_sheet(brief: str, attempts: list[Any], destination: Path, *, model: str) -> Path:
+    """Render the contact sheet and return where it was written."""
+
+    rows = []
+    for attempt in attempts:
+        data = attempt if isinstance(attempt, dict) else asdict(attempt)
+        score = data.get("score")
+        shown = "n/a" if score is None else str(score)
+        tone = "hi" if isinstance(score, int) and score >= 85 else "lo"
+        stderr = data.get("stderr") or ""
+        rows.append(
+            f"""<section class="step">
+  <div>{_img(data.get("image"))}</div>
+  <div>
+    <div class="head"><span class="n">attempt {data.get("index")}</span>
+      <span class="score {tone}">{shown}</span></div>
+    <p class="verdict">{html.escape(str(data.get("verdict") or ""))}</p>
+    <h3>defects the critic saw</h3>{_items([str(d) for d in data.get("defects") or []])}
+    <h3>defects the scene report saw</h3>
+    {_items([str(d) for d in data.get("probe_defects") or []], "probe")}
+    <h3>next actions</h3>{_items([str(a) for a in data.get("next_actions") or []])}
+    {f"<h3>blender stderr</h3><pre>{html.escape(stderr[:1200])}</pre>" if stderr else ""}
+  </div>
+</section>"""
+        )
+
+    scores = [a.get("score") if isinstance(a, dict) else a.score for a in attempts]
+    scores = [s for s in scores if isinstance(s, int)]
+    best = max(scores) if scores else None
+    last = attempts[-1] if attempts else None
+    spent = (last.get("cost_usd") if isinstance(last, dict) else last.cost_usd) if last else 0.0
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(
+        f"""<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>scene agent run</title><style>{CSS}</style></head><body>
+<h1>Scene agent run</h1>
+<p class="sub">{len(attempts)} attempts &middot; best score {best if best is not None else "n/a"}
+ &middot; {html.escape(model)} &middot; ${spent:.4f}</p>
+<div class="brief">{html.escape(brief)}</div>
+{"".join(rows)}
+<footer>Each attempt shows the render the critic saw and the scene-graph report it saw alongside it.
+The two channels catch different failures: an image cannot show a mesh with no faces, and a report
+cannot show a camera pointed at the back of the instrument.</footer>
+</body></html>""",
+        encoding="utf-8",
+    )
+    return destination

--- a/scripts/scene_agent/stage.py
+++ b/scripts/scene_agent/stage.py
@@ -20,7 +20,7 @@ import json
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
-from .client import CRITIC_MODEL, GENERATOR_MODEL, ask, fenced_python
+from .client import CRITIC_MODEL, GENERATOR_MODEL, ask_retrying, fenced_python
 from .loop import SYSTEM, _strings, critique
 from .render import render_script
 
@@ -101,14 +101,21 @@ def build(
                         f"\n\nYour previous attempt failed to run. Fix it.\n{last_error[:1500]}"
                     )
 
-            reply = ask(
-                [
-                    {"role": "system", "content": STAGE_SYSTEM if script else SYSTEM},
-                    {"role": "user", "content": prompt},
-                ],
-                model=model,
-                key=key,
-            )
+            try:
+                reply = ask_retrying(
+                    [
+                        {"role": "system", "content": STAGE_SYSTEM if script else SYSTEM},
+                        {"role": "user", "content": prompt},
+                    ],
+                    model=model,
+                    key=key,
+                )
+            except RuntimeError as exc:
+                # A stage that cannot reach the model is a failed stage, not a failed build. Two
+                # stages had already passed when this last killed the run.
+                last_error = f"the model could not be reached: {exc}"
+                stage.stderr = last_error
+                continue
             spent += reply.cost_usd
             candidate = fenced_python(reply.text)
 

--- a/scripts/scene_agent/stage.py
+++ b/scripts/scene_agent/stage.py
@@ -1,0 +1,189 @@
+"""Build a scene one addition at a time, rendering after each.
+
+A whole workcell in one prompt does not work. Measured against four models, a brief describing a
+bench, an arm, two hotels, a reader, a shaker and their materials exhausts the completion budget in
+reasoning and returns nothing, while a brief describing a bench alone answers in about thirty
+seconds. The difference is not the length of the script; it is how much has to be held at once.
+
+So the scene is assembled the way `examples/digital-twin-surrogate/scene/build_scene.py` is
+organised: a base, then one body at a time, each in its own function, each verifiable on its own.
+Every stage receives the working script and adds exactly one thing, and the render after each stage
+localises the blame. When an arm comes out wrong, it is the arm that is wrong, not the scene.
+
+A failed stage is retried on its own rather than restarting the build, because the cost of a stage
+is one call and the cost of a restart is all of them.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from .client import GENERATOR_MODEL, ask, fenced_python
+from .loop import SYSTEM
+from .render import render_script
+
+STAGE_SYSTEM = (
+    SYSTEM
+    + """
+
+You are extending a script that already works. Return the COMPLETE script with your addition
+folded in, in one fenced python block. Keep everything that is already there, keep the names it
+already uses, and change nothing you were not asked to change. Organise each body into its own
+function so the script stays readable as it grows."""
+)
+
+
+@dataclass
+class Stage:
+    """One addition, and how it went."""
+
+    name: str
+    instruction: str
+    attempts: int = 0
+    ok: bool = False
+    probe_defects: list[str] = field(default_factory=list)
+    stderr: str = ""
+    image: str | None = None
+    meshes: int = 0
+    cost_usd: float = 0.0
+
+
+def build(
+    base_instruction: str,
+    stages: list[tuple[str, str]],
+    out_dir: Path,
+    *,
+    retries: int = 2,
+    model: str = GENERATOR_MODEL,
+    key: str | None = None,
+    width: int = 1280,
+    height: int = 720,
+    samples: int = 128,
+    engine: str = "CYCLES",
+    blender: str | None = None,
+) -> tuple[str, list[Stage]]:
+    """Assemble the scene stage by stage. Returns the final script and the record of each stage."""
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    script = ""
+    record: list[Stage] = []
+    spent = 0.0
+
+    todo = [("base", base_instruction), *stages]
+    for index, (name, instruction) in enumerate(todo):
+        step_dir = out_dir / f"{index:02d}-{name}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+        stage = Stage(name=name, instruction=instruction)
+        last_error = ""
+
+        for attempt in range(1, retries + 2):
+            stage.attempts = attempt
+            if script:
+                prompt = (
+                    f"CURRENT SCRIPT\n```python\n{script}\n```\n\n"
+                    f"ADD THIS, changing nothing else:\n{instruction}"
+                )
+                if last_error:
+                    prompt += (
+                        f"\n\nYour previous attempt failed to run. Fix it.\n{last_error[:1500]}"
+                    )
+            else:
+                prompt = instruction
+                if last_error:
+                    prompt += (
+                        f"\n\nYour previous attempt failed to run. Fix it.\n{last_error[:1500]}"
+                    )
+
+            reply = ask(
+                [
+                    {"role": "system", "content": STAGE_SYSTEM if script else SYSTEM},
+                    {"role": "user", "content": prompt},
+                ],
+                model=model,
+                key=key,
+            )
+            spent += reply.cost_usd
+            candidate = fenced_python(reply.text)
+
+            outcome = render_script(
+                candidate,
+                step_dir,
+                blender=blender,
+                width=width,
+                height=height,
+                engine=engine,
+                samples=samples,
+            )
+            if outcome.ok:
+                script = candidate
+                stage.ok = True
+                stage.image = str(outcome.image)
+                stage.probe_defects = outcome.defects
+                meshes = outcome.report.get("meshes")
+                stage.meshes = int(meshes) if isinstance(meshes, int) else 0
+                break
+            last_error = outcome.stderr or "; ".join(outcome.defects)
+            stage.stderr = last_error
+
+        stage.cost_usd = spent
+        record.append(stage)
+        (step_dir / "scene.py").write_text(script or "", encoding="utf-8")
+        (step_dir / "stage.json").write_text(json.dumps(asdict(stage), indent=2), encoding="utf-8")
+
+        if not stage.ok:
+            break
+
+    if script:
+        (out_dir / "scene.py").write_text(script, encoding="utf-8")
+    (out_dir / "stages.json").write_text(
+        json.dumps([asdict(s) for s in record], indent=2), encoding="utf-8"
+    )
+    return script, record
+
+
+#: The workcell, decomposed. Each entry is one body, in the order that makes the render legible
+#: as it grows: the room, then the surface, then the things on it, then the thing that moves.
+WORKCELL_BASE = """Build a Blender 5.2 scene of an empty laboratory bench, ready for instruments.
+
+- a matte dark-grey bench top 1.8 m wide, 0.8 m deep, 40 mm thick, its top surface at 0.9 m
+- four square steel legs at the corners, 50 mm section
+- a large floor plane in light neutral grey
+- a camera at three-quarter view from the front-left, about 1.6 m high and 3.2 m from the bench
+  centre, framing the whole bench with headroom, and set it as the scene camera
+- a soft area key light from the front-left about 3 m up, a cooler dimmer area fill from the right,
+  and a weak world ambient so shadows are not black
+
+Use metres. Give the bench a slightly rough dark material and the floor a matte light one."""
+
+WORKCELL_STAGES: list[tuple[str, str]] = [
+    (
+        "plate-reader",
+        "Add a plate reader on the left third of the bench top: a matte dark polymer box "
+        "0.45 m wide, 0.35 m deep, 0.25 m tall, with a shallow horizontal slot across the front "
+        "for a loading drawer and a slightly recessed darker front panel. No text or logos.",
+    ),
+    (
+        "shaker",
+        "Add an orbital shaker on the right third of the bench top: a low matte dark base "
+        "0.30 x 0.30 x 0.09 m, with a light grey platform on top and four small corner clamps. "
+        "Place one microplate on the platform, 127.76 x 85.48 x 14 mm, light grey, with a shallow "
+        "recessed grid of 96 wells in 8 rows and 12 columns on its upper face.",
+    ),
+    (
+        "hotels",
+        "Add two plate hotels, one at each rear corner of the bench top: an open vertical rack of "
+        "thin steel uprights 0.5 m tall holding eight microplates in a stack with about 20 mm "
+        "clearance between them. Reuse the microplate geometry already in the script.",
+    ),
+    (
+        "arm",
+        "Add a six-axis robot arm at the centre-rear of the bench top, roughly 0.7 m reach, in "
+        "brushed aluminium. Build it as a real kinematic chain: a cylindrical base, a shoulder "
+        "yoke, an upper arm, a forearm, a wrist, and a two-finger parallel gripper. Pose it "
+        "mid-transfer, leaning forward and to the left, with the gripper closed on a microplate "
+        "held level about 0.25 m above the bench. The plate must sit between the fingers with the "
+        "fingers touching its short edges.",
+    ),
+]

--- a/scripts/scene_agent/stage.py
+++ b/scripts/scene_agent/stage.py
@@ -20,8 +20,8 @@ import json
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
-from .client import GENERATOR_MODEL, ask, fenced_python
-from .loop import SYSTEM
+from .client import CRITIC_MODEL, GENERATOR_MODEL, ask, fenced_python
+from .loop import SYSTEM, _strings, critique
 from .render import render_script
 
 STAGE_SYSTEM = (
@@ -43,6 +43,9 @@ class Stage:
     instruction: str
     attempts: int = 0
     ok: bool = False
+    score: int | None = None
+    verdict: str = ""
+    defects: list[str] = field(default_factory=list)
     probe_defects: list[str] = field(default_factory=list)
     stderr: str = ""
     image: str | None = None
@@ -56,7 +59,9 @@ def build(
     out_dir: Path,
     *,
     retries: int = 2,
+    look_bar: int = 70,
     model: str = GENERATOR_MODEL,
+    critic_model: str = CRITIC_MODEL,
     key: str | None = None,
     width: int = 1280,
     height: int = 720,
@@ -118,13 +123,37 @@ def build(
             )
             blocking = [d for d in outcome.defects if not d.startswith("engine ")]
             if outcome.ok and not blocking:
-                script = candidate
-                stage.ok = True
-                stage.image = str(outcome.image)
-                stage.probe_defects = outcome.defects
-                meshes = outcome.report.get("meshes")
-                stage.meshes = int(meshes) if isinstance(meshes, int) else 0
-                break
+                # Structurally sound. Now ask whether it looks like what was asked for, which is
+                # the question the probe cannot reach: it counted six meshes, all in frame, no
+                # defects, on a render where every surface came out white against a brief that
+                # said matte dark grey.
+                judgement, critic_reply = critique(
+                    instruction, outcome, model=critic_model, key=key
+                )
+                spent += critic_reply.cost_usd
+                raw = judgement.get("score")
+                stage.score = int(raw) if isinstance(raw, (int, float)) else None
+                stage.verdict = str(judgement.get("verdict", ""))
+                stage.defects = _strings(judgement.get("defects"))
+
+                good_enough = stage.score is None or stage.score >= look_bar
+                if good_enough or attempt > retries:
+                    script = candidate
+                    stage.ok = True
+                    stage.image = str(outcome.image)
+                    stage.probe_defects = outcome.defects
+                    meshes = outcome.report.get("meshes")
+                    stage.meshes = int(meshes) if isinstance(meshes, int) else 0
+                    break
+
+                actions = _strings(judgement.get("next_actions"))
+                last_error = (
+                    f"It rendered, but a reviewer scored it {stage.score}/100: {stage.verdict}\n"
+                    f"Defects: {json.dumps(stage.defects, indent=1)}\n"
+                    f"Do this: {json.dumps(actions, indent=1)}"
+                )
+                stage.stderr = last_error
+                continue
             # A render that ran is not a render that shows anything. Blocking defects carry the
             # structural failures an image cannot report and, since the framing check landed, the
             # one an image reports loudest: a camera pointed at nothing.

--- a/scripts/scene_agent/stage.py
+++ b/scripts/scene_agent/stage.py
@@ -116,7 +116,8 @@ def build(
                 engine=engine,
                 samples=samples,
             )
-            if outcome.ok:
+            blocking = [d for d in outcome.defects if not d.startswith("engine ")]
+            if outcome.ok and not blocking:
                 script = candidate
                 stage.ok = True
                 stage.image = str(outcome.image)
@@ -124,8 +125,15 @@ def build(
                 meshes = outcome.report.get("meshes")
                 stage.meshes = int(meshes) if isinstance(meshes, int) else 0
                 break
-            last_error = outcome.stderr or "; ".join(outcome.defects)
+            # A render that ran is not a render that shows anything. Blocking defects carry the
+            # structural failures an image cannot report and, since the framing check landed, the
+            # one an image reports loudest: a camera pointed at nothing.
+            if outcome.ok and blocking:
+                last_error = "The script ran and rendered, but: " + "; ".join(blocking)
+            else:
+                last_error = outcome.stderr or "; ".join(outcome.defects)
             stage.stderr = last_error
+            stage.probe_defects = outcome.defects
 
         stage.cost_usd = spent
         record.append(stage)


### PR DESCRIPTION
Tooling only. **2,923 insertions across 10 files, all under `scripts/`, all additive** — nothing
modified, nothing removed, no framework code touched. `make lint` clean, **723 tests pass**.

## What it does

    brief → staged generation → 9 deterministic checks → visual critique
          → GLB + sha256 + draft twin.yaml → opensdl twin validate ✓

`export.py` is the piece with a waiting consumer: it exports a generated Blender scene, digests it,
and drafts a `twin.yaml` in the shape `examples/digital-twin-surrogate/twin.yaml` already uses. The
framework's own validator accepts the result, digest check included, so a generated scene is a real
OpenSDL asset rather than an image that resembles one.

`openrouter_bridge.py` serves the Anthropic Messages API on top of OpenRouter. Claude Code honours
`ANTHROPIC_BASE_URL` — verified by pointing it at a listener and watching it POST
`/v1/messages?beta=true` — so this puts any OpenRouter model inside this harness with its real
tools. Tool definitions, `tool_use`/`tool_result` blocks, images and stop reasons all translate.

## Nine checks, seven of which the critic found first

| channel | catches |
|---|---|
| structural | no camera, no light, faceless meshes, non-finite transforms |
| framing | nothing in shot, most of it out of shot |
| cropping | a body cut by the frame edge |
| exposure | blown, crushed, flat, or under-lit |
| coplanar | surfaces that overlap in plan and share a height |
| containment | a detail modelled inside a solid body |
| facing | a feature on a face the camera cannot see |
| material separation | a subject too close in value to the ground it stands on |
| visual | a scored critique from a model that can see the render |

Exposure, coplanar, cropping, containment, separation and facing all began as something the visual
critic noticed by eye and became free deterministic checks. Expensive eye finds the class once;
cheap code catches every instance after.

## Calibrated, not chosen

The palette came from a rendered swatch ramp, 0.03 to 0.22 albedo against floors at 0.55, 0.30 and
0.18. The finding that mattered: **the floor dominates.** At 0.55 it bounces enough light that even
a 0.03 surface reads mid-grey and nothing in the scene can look dark. Lighting energies came from
exposure measurements, metal roughness from a specular test.

## What the prelude is for

Twenty-five helpers, and the list is a history of what went wrong. Prose guidance failed every
time — telling the model `scene.world` starts as None produced a script that checked
`world.use_nodes` anyway; a camera-aiming recipe in words produced `tuple - Vector`. Working code is
not misread the way a sentence is.

It also repairs calls rather than rejecting them: a synonym for a parameter name, a material in a
numeric slot, a group where an object was expected, an object where a point belongs. The model
reasons well about what it wants and is unreliable about the shape of the request, and rejecting a
legible request costs an attempt while accepting it costs nothing.

## Honest limits

- The **scene is not finished.** Base passes at 58–74; the build reaches stage 2 and has never
  cleared it. Hotels and arm are unbuilt, though `strut`/`joint`/`gripper` are tested independently.
- The generated `twin.yaml` is a **draft** and says so in the file. It lists bodies and leaves
  `resources: []` empty; what is a resource is a laboratory decision.
- Needs an OpenRouter key and a local Blender. Neither is a framework dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D474cFdhB3DeTu2sKt7VuE